### PR TITLE
Add ability to audit/update azure-cli setup.py in `azdev verify version` command

### DIFF
--- a/azdev/help.py
+++ b/azdev/help.py
@@ -86,11 +86,11 @@ helps['verify version'] = """
         This is used to ensure the correct module versions are bumped prior to release and that all
         module versions are present in the azure-cli setup.py with their versions pinned.
     examples:
-        - name: Verify all versions and update azure-cli's setup.py with each module's verison.
+        - name: Verify all versions and audit them against azure-cli's setup.py ONLY.
           text: azdev verify version
 
-        - name: Verify all versions and audit them against azure-cli's setup.py ONLY.
-          text: azdev verify version --no-update
+        - name: Verify all versions and update azure-cli's setup.py with each module's verison.
+          text: azdev verify version --update
 """
 
 

--- a/azdev/help.py
+++ b/azdev/help.py
@@ -81,7 +81,16 @@ helps['verify history'] = """
 
 
 helps['verify version'] = """
-    short-summary: Verify package versions.
+    short-summary: Verify package versions against those hosted on PyPI and/or in the azure-cli setup.py file.
+    long-summary: >
+        This is used to ensure the correct module versions are bumped prior to release and that all
+        module versions are present in the azure-cli setup.py with their versions pinned.
+    examples:
+        - name: Verify all versions and update azure-cli's setup.py with each module's verison.
+          text: azdev verify version
+
+        - name: Verify all versions and audit them against azure-cli's setup.py ONLY.
+          text: azdev verify version --no-update
 """
 
 

--- a/azdev/operations/pypi.py
+++ b/azdev/operations/pypi.py
@@ -5,8 +5,10 @@
 # -----------------------------------------------------------------------------
 
 import os
+import re
 import sys
 
+from distutils.version import LooseVersion  # pylint:disable=import-error,no-name-in-module
 from docutils import core, io
 
 from knack.log import get_logger
@@ -14,7 +16,7 @@ from knack.util import CLIError
 
 from azdev.utilities import (
     display, heading, subheading, cmd, py_cmd, get_path_table,
-    pip_cmd, COMMAND_MODULE_PREFIX, require_azure_cli)
+    pip_cmd, COMMAND_MODULE_PREFIX, require_azure_cli, find_files)
 
 logger = get_logger(__name__)
 
@@ -240,13 +242,17 @@ def _check_readme_render(mod_path):
 
 
 # region verify PyPI versions
-def verify_versions(modules=None):
+def verify_versions(modules=None, no_update=False):
     import tempfile
     import shutil
 
     require_azure_cli()
 
     heading('Verify Package Versions')
+
+    if modules:
+        logger.warning('When checking individual modules, azure-cli\'s setup.py file will be ignored!\n')
+        no_update = None
 
     original_cwd = os.getcwd()
     path_table = get_path_table(include_only=modules)
@@ -261,36 +267,109 @@ def verify_versions(modules=None):
 
     results = {}
     for mod, mod_path in modules:
-        if not mod.startswith(COMMAND_MODULE_PREFIX):
+        if not mod.startswith(COMMAND_MODULE_PREFIX) and mod != 'azure-cli':
             mod = '{}{}'.format(COMMAND_MODULE_PREFIX, mod)
         # currently, this is not published
         if mod == 'azure-cli-testsdk':
             continue
-        results.update(_check_module(temp_dir, mod, mod_path))
+        results.update(_compare_module_against_pypi(temp_dir, mod, mod_path))
 
     shutil.rmtree(temp_dir)
     os.chdir(original_cwd)
+
+    results = _check_setup_py(results, no_update)
 
     logger.info('Module'.ljust(40) + 'Local Version'.rjust(20) + 'Public Version'.rjust(20))  # pylint: disable=logging-not-lazy
     for mod, data in results.items():
         logger.info(mod.ljust(40) + data['local_version'].rjust(20) + data['public_version'].rjust(20))
 
-    failed_mods = {k: v for k, v in results.items() if v['status'] != 'OK'}
+    bump_mods = {k: v for k, v in results.items() if v['status'] == 'BUMP'}
+    mismatch_mods = {k: v for k, v in results.items() if v['status'] == 'MISMATCH'}
     subheading('RESULTS')
-    if failed_mods:
+    if bump_mods:
         logger.error('The following modules need their versions bumped. '
-                     'Scroll up for details: %s', ', '.join(failed_mods.keys()))
+                     'Scroll up for details: %s', ', '.join(bump_mods.keys()))
         logger.warning('\nNote that before changing versions, you should consider '
                        'running `git clean` to remove untracked files from your repo. '
                        'Files that were once tracked but removed from the source may '
                        'still be on your machine, resuling in false positives.')
+    elif mismatch_mods and no_update:
+        logger.error('The following modules have a mismatch between the module version '
+                     'and the version in azure-cli\'s setup.py file. '
+                     'Scroll up for details: %s', ', '.join(mismatch_mods.keys()))
     else:
         display('OK!')
 
 
+def _check_setup_py(results, no_update):
+    # only audit or update setup.py when all modules are being considered
+    # otherwise, edge cases could arise
+    if no_update is None:
+        return results
+
+    # retrieve current versions from azure-cli's setup.py file
+    azure_cli_path = get_path_table(include_only='azure-cli')['core']['azure-cli']
+    azure_cli_setup_path = find_files(azure_cli_path, SETUP_PY_NAME)[0]
+    with open(azure_cli_setup_path, 'r') as f:
+        setup_py_version_regex = re.compile(r"'([^'=]*)==([\d.]*)'")
+        for line in f.readlines():
+            if line.strip().startswith("'azure-cli-"):
+                match = setup_py_version_regex.match(line.strip())
+                mod = match.group(1)
+                if mod == 'azure-cli-command-modules-nspkg':
+                    mod = 'azure-cli-command_modules-nspkg'
+                try:
+                    results[mod]['setup_version'] = match.group(2)
+                except KeyError:
+                    # something that is in setup.py but isn't module is
+                    # inherently a mismatch
+                    results[mod] = {
+                        'local_version': 'Unavailable',
+                        'public_version': 'Unknown',
+                        'setup_version': match.group(2),
+                        'status': 'MISMATCH'
+                    }
+
+    if no_update:
+        display('\nAuditing azure-cli setup.py against local module versions...')
+        for mod, data in results.items():
+            if mod == 'azure-cli':
+                continue
+            if data['local_version'] != data['setup_version']:
+                data['status'] = 'MISMATCH'
+        return results
+
+    # update azure-cli's setup.py file with the collected versions
+    logger.warning('\nUpdating azure-cli setup.py with collected module versions...')
+    old_lines = []
+    with open(azure_cli_setup_path, 'r') as f:
+        old_lines = f.readlines()
+
+    with open(azure_cli_setup_path, 'w') as f:
+        start_line = 'DEPENDENCIES = ['
+        end_line = ']'
+        write_versions = False
+
+        for line in old_lines:
+            if line.strip() == start_line:
+                write_versions = True
+                f.write(line)
+                for mod, data in results.items():
+                    if mod == 'azure-cli' or data['local_version'] == 'Unavailable':
+                        continue
+                    f.write("    '{}=={}'\n".format(mod, data['local_version']))
+                continue
+            elif line.strip() == end_line:
+                write_versions = False
+            elif write_versions:
+                # stop writing lines until the end bracket is found
+                continue
+            f.write(line)
+    return results
+
+
 # pylint: disable=too-many-statements
-def _check_module(root_dir, mod, mod_path):
-    import re
+def _compare_module_against_pypi(root_dir, mod, mod_path):
     import zipfile
 
     version_pattern = re.compile(r'.*azure_cli[^-]*-(\d*.\d*.\d*).*')
@@ -333,13 +412,20 @@ def _check_module(root_dir, mod, mod_path):
     build_path = os.path.join(build_dir, os.listdir(build_dir)[0])
     build_version = version_pattern.match(build_path).group(1)
 
-    if build_version != downloaded_version:
-        # TODO: Make this more robust? What if local version < public?
-        results[mod] = {
-            'local_version': build_version,
-            'public_version': downloaded_version,
-            'status': 'OK'
-        }
+    results[mod] = {
+        'local_version': build_version,
+        'public_version': downloaded_version,
+        'setup_version': None,
+        'status': None
+    }
+
+    # OK if package is new
+    if downloaded_version == 'Unavailable':
+        results[mod]['status'] = 'OK'
+        return results
+    # OK if local version is higher than what's on PyPI
+    if LooseVersion(build_version) > LooseVersion(downloaded_version):
+        results[mod]['status'] = 'OK'
         return results
 
     # slight difference in dist-info dirs, so we must extract the azure folders and compare them
@@ -356,17 +442,13 @@ def _check_module(root_dir, mod, mod_path):
         subheading('Differences found in {}'.format(mod))
         for error in errors:
             logger.warning(error)
-    results[mod] = {
-        'local_version': build_version,
-        'public_version': downloaded_version,
-        'status': 'OK' if not errors else 'ERROR'
-    }
+    results[mod]['status'] = 'OK' if not errors else 'BUMP'
 
-    # special case: to make a release, these MUST be bumped
+    # special case: to make a release, these MUST be bumped, even if it wouldn't otherwise be necessary
     if mod in ['azure-cli', 'azure-cli-core']:
         if results[mod]['status'] == 'OK':
             logger.warning('%s version must be bumped to support release!', mod)
-            results[mod]['status'] = 'ERROR'
+            results[mod]['status'] = 'BUMP'
 
     return results
 

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -54,7 +54,7 @@ def load_arguments(self, _):
             c.positional('modules', nargs='*', help='Space-separated list of modules to check.')
 
     with ArgumentsContext(self, 'verify version') as c:
-        c.argument('no_update', action='store_true', help='If provided, the command will audit versions in modules against setup.py but not update anything.')
+        c.argument('update', action='store_true', help='If provided, the command will update the versions in azure-cli\'s setup.py file.')
 
     with ArgumentsContext(self, 'linter') as c:
         c.positional('modules', nargs='*', help='Space-separated list of modules or extensions to check.')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -53,9 +53,8 @@ def load_arguments(self, _):
         with ArgumentsContext(self, 'verify {}'.format(scope)) as c:
             c.positional('modules', nargs='*', help='Space-separated list of modules to check.')
 
-    with ArgumentsContext(self, 'verify versions') as c:
-        c.argument('base_repo', help='Path to directory containeing the CLI repo with the base versions to compare against.')
-        c.argument('base_tag', help='The Git tag name that represents the base repo.')
+    with ArgumentsContext(self, 'verify version') as c:
+        c.argument('no_update', action='store_true', help='If provided, the command will audit versions in modules against setup.py but not update anything.')
 
     with ArgumentsContext(self, 'linter') as c:
         c.positional('modules', nargs='*', help='Space-separated list of modules or extensions to check.')


### PR DESCRIPTION
Closes #31.

New usage:
- `azdev verify version --update` - will verify local versions against PyPI AND update setup.py with the current versions. This would be run on the release branch to bump necessary module versions and ensure setup.py for azure-cli reflects those versions.

- `azdev verify version <MOD>` - will verify local versions against PyPI but do nothing with azure-cli setup.py file.

- `azdev verify version` - will verify local versions against PyPI and audit local versions against the azure-cli setup.py file. This would be run as a precheck in the publish phase.