### PR TITLE
Small fixes to support running from Travis CI

### DIFF
--- a/azdev/operations/pypi.py
+++ b/azdev/operations/pypi.py
@@ -27,8 +27,6 @@ SETUP_PY_NAME = 'setup.py'
 # region verify History Headings
 def check_history(modules=None):
 
-    require_azure_cli()
-
     # TODO: Does not work with extensions
     path_table = get_path_table(include_only=modules)
     selected_modules = list(path_table['core'].items()) + list(path_table['mod'].items())
@@ -91,7 +89,8 @@ def _check_history_headings(mod_path):
 
         first_version_history = all_versions[0]
         actual_version = cmd('python setup.py --version', cwd=mod_path)
-        actual_version = actual_version.result.strip()
+        # command can output warnings as well, so we just want the last line, which should have the version
+        actual_version = actual_version.result.splitlines()[-1].strip()
         if first_version_history != actual_version:
             errors.append("The topmost version in {} does not match version {} defined in setup.py.".format(
                 history_path, actual_version))

--- a/azdev/operations/style.py
+++ b/azdev/operations/style.py
@@ -14,7 +14,7 @@ from knack.util import CLIError, CommandResultItem
 
 from azdev.utilities import (
     display, heading, subheading, py_cmd, get_path_table, EXTENSION_PREFIX,
-    get_env_config_dir)
+    get_env_config_dir, require_azure_cli)
 
 
 logger = get_logger(__name__)
@@ -27,6 +27,12 @@ def check_style(modules=None, pylint=False, pep8=False):
     selected_modules = get_path_table(include_only=modules)
     pep8_result = None
     pylint_result = None
+
+    if pylint:
+        try:
+            require_azure_cli()
+        except CLIError:
+            raise CLIError('usage error: --pylint requires Azure CLI to be installed.')
 
     if not selected_modules:
         raise CLIError('No modules selected.')

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'azdev.config',
         'azdev.operations',
         'azdev.operations.linter',
+        'azdev.operations.linter.rules',
         'azdev.operations.tests',
         'azdev.operations.extensions',
         'azdev.utilities',
@@ -64,7 +65,7 @@ setup(
         ":python_version<'3.0'": ['pylint~=1.9.2'],
         ":python_version>='3.0'": ['pylint~=2.0.0']
     },
-    package_data={'azdev.config': ['*.*']},
+    package_data={'azdev.config': ['*.*', 'cli_pylintrc', 'ext_pylintrc']},
     include_package_data=True,
     entry_points={
         'console_scripts': ['azdev=azdev.__main__:main']


### PR DESCRIPTION
- Add missing package for linter.
- Fix up history verification for CI mode.
- Allow pep8 to run without CLI. Require only if running pylint.
- Fix #21 (hopefully)