### PR TITLE
Azdev Fixes to work with Azure-CLI CI

### DIFF
--- a/azdev/commands.py
+++ b/azdev/commands.py
@@ -27,7 +27,10 @@ def load_command_table(self, _):
 
     with CommandGroup(self, 'verify', operation_group('pypi')) as g:
         g.command('history', 'check_history')
-        g.command('version', 'verify_versions')
+
+    with CommandGroup(self, 'cli', operation_group('pypi')) as g:
+        g.command('check-versions', 'verify_versions')
+        g.command('update-setup', 'update_setup_py')
 
     with CommandGroup(self, 'verify', operation_group('help')) as g:
         g.command('document-map', 'check_document_map')

--- a/azdev/help.py
+++ b/azdev/help.py
@@ -29,6 +29,33 @@ helps['setup'] = """
 """
 
 
+helps['cli'] = """
+    short-summary: Commands for working with CLI modules.
+"""
+
+helps['cli check-versions'] = """
+    short-summary: Verify package versions against those hosted on PyPI and/or in the azure-cli setup.py file.
+    long-summary: >
+        This is used to ensure the correct module versions are bumped prior to release.
+    examples:
+        - name: Verify all versions and audit them against azure-cli's setup.py ONLY.
+          text: azdev cli check-versions
+
+        - name: Verify all versions and update azure-cli's setup.py with each module's verison.
+          text: azdev cli check-versions --update --pin
+"""
+
+helps['cli update-setup'] = """
+    short-summary: Update the azure-cli setup.py file.
+    examples:
+        - name: Update azure-cli's setup.py with unpinned module verions.
+          text: azdev cli update-setup
+
+        - name: Update azure-cli's setup.py with pinned module versions.
+          text: azdev cli update-setup --pin
+"""
+
+
 helps['configure'] = """
     short-summary: Configure azdev for use without installing anything.
 """
@@ -77,20 +104,6 @@ helps['verify package'] = """
 
 helps['verify history'] = """
     short-summary: Verify the README and HISTORY files for each module so they format correctly on PyPI.
-"""
-
-
-helps['verify version'] = """
-    short-summary: Verify package versions against those hosted on PyPI and/or in the azure-cli setup.py file.
-    long-summary: >
-        This is used to ensure the correct module versions are bumped prior to release and that all
-        module versions are present in the azure-cli setup.py with their versions pinned.
-    examples:
-        - name: Verify all versions and audit them against azure-cli's setup.py ONLY.
-          text: azdev verify version
-
-        - name: Verify all versions and update azure-cli's setup.py with each module's verison.
-          text: azdev verify version --update
 """
 
 

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 
 
 # pylint:disable=too-many-locals
-def run_linter(modules=None, rule_types=None, rules=None, ci_mode=False):
+def run_linter(modules=None, rule_types=None, rules=None):
 
     require_azure_cli()
 
@@ -39,12 +39,15 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_mode=False):
     # needed to remove helps from azdev
     azdev_helps = helps.copy()
     exclusions = {}
-    path_table = get_path_table(include_only=modules)
+    selected_modules = get_path_table(include_only=modules)
 
-    selected_mod_names = list(path_table['mod'].keys()) + list(path_table['core'].keys()) + \
-        list(path_table['ext'].keys())
-    selected_mod_paths = list(path_table['mod'].values()) + list(path_table['core'].values()) + \
-        list(path_table['ext'].values())
+    if not selected_modules:
+        raise CLIError('No modules selected.')
+
+    selected_mod_names = list(selected_modules['mod'].keys()) + list(selected_modules['core'].keys()) + \
+        list(selected_modules['ext'].keys())
+    selected_mod_paths = list(selected_modules['mod'].values()) + list(selected_modules['core'].values()) + \
+        list(selected_modules['ext'].values())
 
     # collect all rule exclusions
     for path in selected_mod_paths:
@@ -99,6 +102,5 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_mode=False):
         run_params=not rule_types or 'params' in rule_types,
         run_commands=not rule_types or 'commands' in rule_types,
         run_command_groups=not rule_types or 'command_groups'in rule_types,
-        run_help_files_entries=not rule_types or 'help_entries' in rule_types,
-        ci=ci_mode)
+        run_help_files_entries=not rule_types or 'help_entries' in rule_types)
     sys.exit(exit_code)

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -49,6 +49,9 @@ def run_linter(modules=None, rule_types=None, rules=None):
     selected_mod_paths = list(selected_modules['mod'].values()) + list(selected_modules['core'].values()) + \
         list(selected_modules['ext'].values())
 
+    if selected_mod_names:
+        display('Modules: {}\n'.format(', '.join(selected_mod_names)))
+
     # collect all rule exclusions
     for path in selected_mod_paths:
         exclusion_path = os.path.join(path, 'linter_exclusions.yml')

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -188,7 +188,7 @@ class LinterManager(object):
     def exit_code(self):
         return self._exit_code
 
-    def run(self, run_params=None, run_commands=None, run_command_groups=None, run_help_files_entries=None, ci=False):
+    def run(self, run_params=None, run_commands=None, run_command_groups=None, run_help_files_entries=None):
         self._ci = os.environ.get('CI', False)
         paths = import_module('{}.rules'.format(PACAKGE_NAME)).__path__
 

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -189,7 +189,7 @@ class LinterManager(object):
         return self._exit_code
 
     def run(self, run_params=None, run_commands=None, run_command_groups=None, run_help_files_entries=None, ci=False):
-        self._ci = ci
+        self._ci = os.environ.get('CI', False)
         paths = import_module('{}.rules'.format(PACAKGE_NAME)).__path__
 
         if paths:

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -7,6 +7,8 @@
 import copy
 import re
 
+from azdev.utilities import COMMAND_MODULE_PREFIX
+
 from knack.log import get_logger
 
 
@@ -38,6 +40,7 @@ def exclude_commands(command_loader, help_file_entries, module_exclusions):
 
 def _filter_mods(command_loader, help_file_entries, modules=None, exclude=False):
     modules = modules or []
+    modules = [x.replace(COMMAND_MODULE_PREFIX, '') for x in modules]
 
     # command tables and help entries must be copied to allow for seperate linter scope
     command_table = command_loader.command_table.copy()
@@ -64,6 +67,7 @@ def _filter_mods(command_loader, help_file_entries, modules=None, exclude=False)
     # Remove unneeded command groups
     retained_command_groups = {' '.join(x.split(' ')[:-1]) for x in command_loader.command_table}
     excluded_command_groups = set(command_loader.command_group_table.keys()) - retained_command_groups
+
     for group_name in excluded_command_groups:
         command_loader.command_group_table.pop(group_name, None)
         help_file_entries.pop(group_name, None)

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -12,7 +12,6 @@ from knack.log import get_logger
 from azdev.utilities import COMMAND_MODULE_PREFIX
 
 
-
 logger = get_logger(__name__)
 
 

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -7,9 +7,10 @@
 import copy
 import re
 
+from knack.log import get_logger
+
 from azdev.utilities import COMMAND_MODULE_PREFIX
 
-from knack.log import get_logger
 
 
 logger = get_logger(__name__)

--- a/azdev/operations/performance.py
+++ b/azdev/operations/performance.py
@@ -24,6 +24,7 @@ THRESHOLDS = {
 }
 
 
+# pylint: disable=too-many-statements
 def check_load_time(runs=3):
 
     require_azure_cli()
@@ -61,7 +62,7 @@ def check_load_time(runs=3):
     failed_mods = {}
 
     def _claim_higher_threshold(val):
-        avail_thresholds = {k:v for k, v in THRESHOLDS.items() if v}
+        avail_thresholds = {k: v for k, v in THRESHOLDS.items() if v}
         new_threshold = None
         for threshold in sorted(avail_thresholds):
             if val < threshold:

--- a/azdev/operations/pypi.py
+++ b/azdev/operations/pypi.py
@@ -25,6 +25,10 @@ HISTORY_NAME = 'HISTORY.rst'
 RELEASE_HISTORY_TITLE = 'Release History'
 SETUP_PY_NAME = 'setup.py'
 
+# modules which should not be included in setup.py
+# because they aren't on PyPI
+EXCLUDED_MODULES = ['azure-cli-testsdk']
+
 
 # region verify History Headings
 def check_history(modules=None):
@@ -240,44 +244,70 @@ def _check_readme_render(mod_path):
 # endregion
 
 
-# region verify PyPI versions
-def verify_versions(modules=None, update=False):
+def update_setup_py(pin=False):
     import tempfile
     import shutil
 
     require_azure_cli()
 
-    heading('Verify Package Versions')
+    heading('Update azure-cli setup.py')
+
+    path_table = get_path_table()
+    azure_cli_path = path_table['core']['azure-cli']
+    azure_cli_setup_path = find_files(azure_cli_path, SETUP_PY_NAME)[0]
+
+    modules = list(path_table['core'].items()) + list(path_table['mod'].items())
+    modules = [x for x in modules if x[0] not in EXCLUDED_MODULES]
+
+    results = {mod[0]:{} for mod in modules}
+
+    results = _get_module_versions(results, modules)
+    _update_setup_py(results, azure_cli_setup_path, pin)
+
+    display('OK!')
+
+
+# region verify PyPI versions
+def verify_versions(modules=None, update=False, pin=False):
+    import tempfile
+    import shutil
+
+    require_azure_cli()
+
+    heading('Verify CLI Module Versions')
+
+    usage_err = CLIError('usage error: <MODULES> | --update [--pin]')
+    if modules and (update or pin):
+        raise usage_err
+    elif not modules and pin and not update:
+        raise usage_err
 
     if modules:
-        logger.warning('When checking individual modules, azure-cli\'s setup.py file will be ignored!\n')
         update = None
+        pin = None
 
-    original_cwd = os.getcwd()
     path_table = get_path_table(include_only=modules)
     modules = list(path_table['core'].items()) + list(path_table['mod'].items())
+    modules = [x for x in modules if x[0] not in EXCLUDED_MODULES]
 
     if not modules:
         raise CLIError('No modules selected to test.')
 
     display('MODULES: {}'.format(', '.join([x[0] for x in modules])))
 
+    results = {mod[0]:{} for mod in modules}
+
+    original_cwd = os.getcwd()
     temp_dir = tempfile.mkdtemp()
-
-    results = {}
-
     for mod, mod_path in modules:
         if not mod.startswith(COMMAND_MODULE_PREFIX) and mod != 'azure-cli':
             mod = '{}{}'.format(COMMAND_MODULE_PREFIX, mod)
-        # currently, this is not published
-        if mod == 'azure-cli-testsdk':
-            continue
-        results.update(_compare_module_against_pypi(temp_dir, mod, mod_path))
+        results.update(_compare_module_against_pypi(results, temp_dir, mod, mod_path))
 
     shutil.rmtree(temp_dir)
     os.chdir(original_cwd)
 
-    results = _check_setup_py(results, update)
+    results = _check_setup_py(results, update, pin)
 
     logger.info('Module'.ljust(40) + 'Local Version'.rjust(20) + 'Public Version'.rjust(20))  # pylint: disable=logging-not-lazy
     for mod, data in results.items():
@@ -301,7 +331,66 @@ def verify_versions(modules=None, update=False):
         display('OK!')
 
 
-def _check_setup_py(results, update):
+def _get_module_versions(results, modules):
+
+    version_pattern = re.compile(r'.*(?P<ver>\d+.\d+.\d+).*')
+
+    for mod, mod_path in modules:
+        if not mod.startswith(COMMAND_MODULE_PREFIX) and mod != 'azure-cli':
+            mod = '{}{}'.format(COMMAND_MODULE_PREFIX, mod)
+
+        setup_path = find_files(mod_path, 'setup.py')
+        with open(setup_path[0], 'r') as f:
+            local_version = 'Unknown'
+            for line in f.readlines():
+                if line.strip().startswith('VERSION'):
+                    local_version = version_pattern.match(line).group('ver')
+                    break
+            results[mod]['local_version'] = local_version
+    return results
+
+
+def _update_setup_py(results, azure_cli_setup_path, pin):
+
+    # update azure-cli's setup.py file with the collected versions
+    if pin:
+        logger.warning('\nUpdating azure-cli setup.py with collected module versions...')
+    else:
+        logger.warning('\nUpdating azure-cli setup.py with collected modules...')
+
+    old_lines = []
+    with open(azure_cli_setup_path, 'r') as f:
+        old_lines = f.readlines()
+
+    with open(azure_cli_setup_path, 'w') as f:
+        start_line = 'DEPENDENCIES = ['
+        end_line = ']'
+        write_versions = False
+
+        for line in old_lines:
+            if line.strip() == start_line:
+                write_versions = True
+                f.write(line)
+                version_strings = []
+                for mod, data in sorted(results.items()):
+                    if mod == 'azure-cli' or data['local_version'] == 'Unavailable':
+                        continue
+                    if pin:
+                        version_strings.append("    '{}=={}'".format(mod, data['local_version']))
+                    else:
+                        version_strings.append("    '{}'".format(mod))
+                f.write(',\n'.join(version_strings))
+                f.write('\n')
+                continue
+            elif line.strip() == end_line:
+                write_versions = False
+            elif write_versions:
+                # stop writing lines until the end bracket is found
+                continue
+            f.write(line)
+
+
+def _check_setup_py(results, update, pin):
     # only audit or update setup.py when all modules are being considered
     # otherwise, edge cases could arise
     if update is None:
@@ -311,7 +400,7 @@ def _check_setup_py(results, update):
     azure_cli_path = get_path_table(include_only='azure-cli')['core']['azure-cli']
     azure_cli_setup_path = find_files(azure_cli_path, SETUP_PY_NAME)[0]
     with open(azure_cli_setup_path, 'r') as f:
-        setup_py_version_regex = re.compile(r"(?P<quote>[\"'])(?P<mod>[^'=]*)==(?P<ver>[\d.]*)(?P=quote)")
+        setup_py_version_regex = re.compile(r"(?P<quote>[\"'])(?P<mod>[^'=]*)(==(?P<ver>[\d.]*))?(?P=quote)")
         for line in f.readlines():
             if line.strip().startswith("'azure-cli-"):
                 match = setup_py_version_regex.match(line.strip())
@@ -330,51 +419,28 @@ def _check_setup_py(results, update):
                         'status': 'MISMATCH'
                     }
 
-    if not update:
+    if update:
+        _update_setup_py(results, azure_cli_setup_path, pin)
+    else:
         display('\nAuditing azure-cli setup.py against local module versions...')
         for mod, data in results.items():
             if mod == 'azure-cli':
                 continue
-            if data['local_version'] != data['setup_version']:
+            setup_version = data['setup_version']
+            if not setup_version:
+                logger.warning('The azure-cli setup.py file is not using pinned versions. Aborting audit.')
+                break
+            elif setup_version != data['local_version']:
                 data['status'] = 'MISMATCH'
-        return results
-
-    # update azure-cli's setup.py file with the collected versions
-    logger.warning('\nUpdating azure-cli setup.py with collected module versions...')
-    old_lines = []
-    with open(azure_cli_setup_path, 'r') as f:
-        old_lines = f.readlines()
-
-    with open(azure_cli_setup_path, 'w') as f:
-        start_line = 'DEPENDENCIES = ['
-        end_line = ']'
-        write_versions = False
-
-        for line in old_lines:
-            if line.strip() == start_line:
-                write_versions = True
-                f.write(line)
-                for mod, data in results.items():
-                    if mod == 'azure-cli' or data['local_version'] == 'Unavailable':
-                        continue
-                    f.write("    '{}=={}'\n".format(mod, data['local_version']))
-                continue
-            elif line.strip() == end_line:
-                write_versions = False
-            elif write_versions:
-                # stop writing lines until the end bracket is found
-                continue
-            f.write(line)
     return results
 
 
 # pylint: disable=too-many-statements
-def _compare_module_against_pypi(root_dir, mod, mod_path):
+def _compare_module_against_pypi(results, root_dir, mod, mod_path):
     import zipfile
 
     version_pattern = re.compile(r'.*azure_cli[^-]*-(\d*.\d*.\d*).*')
 
-    results = {}
     downloaded_path = None
     downloaded_version = None
     build_path = None
@@ -412,12 +478,10 @@ def _compare_module_against_pypi(root_dir, mod, mod_path):
     build_path = os.path.join(build_dir, os.listdir(build_dir)[0])
     build_version = version_pattern.match(build_path).group(1)
 
-    results[mod] = {
+    results[mod].update({
         'local_version': build_version,
-        'public_version': downloaded_version,
-        'setup_version': None,
-        'status': None
-    }
+        'public_version': downloaded_version
+    })
 
     # OK if package is new
     if downloaded_version == 'Unavailable':

--- a/azdev/operations/pypi.py
+++ b/azdev/operations/pypi.py
@@ -245,8 +245,6 @@ def _check_readme_render(mod_path):
 
 
 def update_setup_py(pin=False):
-    import tempfile
-    import shutil
 
     require_azure_cli()
 

--- a/azdev/operations/pypi.py
+++ b/azdev/operations/pypi.py
@@ -257,7 +257,7 @@ def update_setup_py(pin=False):
     modules = list(path_table['core'].items()) + list(path_table['mod'].items())
     modules = [x for x in modules if x[0] not in EXCLUDED_MODULES]
 
-    results = {mod[0]:{} for mod in modules}
+    results = {mod[0]: {} for mod in modules}
 
     results = _get_module_versions(results, modules)
     _update_setup_py(results, azure_cli_setup_path, pin)
@@ -293,7 +293,7 @@ def verify_versions(modules=None, update=False, pin=False):
 
     display('MODULES: {}'.format(', '.join([x[0] for x in modules])))
 
-    results = {mod[0]:{} for mod in modules}
+    results = {mod[0]: {} for mod in modules}
 
     original_cwd = os.getcwd()
     temp_dir = tempfile.mkdtemp()

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -20,7 +20,6 @@ def load_arguments(self, _):
 
     with ArgumentsContext(self, '') as c:
         c.argument('modules', options_list=['--modules', '-m'], nargs='+', help='Space-separated list of modules to check. Omit to check all.')
-        c.argument('ci_mode', options_list='--ci', action='store_true', help='Run in CI mode.')
         c.argument('private', action='store_true', help='Target the private repo.')
 
     with ArgumentsContext(self, 'setup') as c:
@@ -29,7 +28,6 @@ def load_arguments(self, _):
         c.argument('ext', options_list=['--ext', '-e'], nargs='+', help='Space-separated list of extensions to install initially.')
 
     with ArgumentsContext(self, 'test') as c:
-        c.argument('ci_mode', options_list='--ci', action='store_true', help='Run the tests in CI mode.')
         c.argument('discover', options_list='--discover', action='store_true', help='Build an index of test names so that you don\'t need to specify fully qualified test paths.')
         c.argument('xml_path', options_list='--xml-path', help='Path and filename at which to store the results in XML format. If omitted, the file will be saved as `test_results.xml` in your `.azdev` directory.')
         c.argument('in_series', options_list='--series', action='store_true', help='Disable test parallelization.')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -55,6 +55,7 @@ def load_arguments(self, _):
 
     with ArgumentsContext(self, 'verify version') as c:
         c.argument('update', action='store_true', help='If provided, the command will update the versions in azure-cli\'s setup.py file.')
+        c.argument('pin', action='store_true', help='If provided and used with --update, will pin the module versions in azure-cli\'s setup.py file.')
 
     with ArgumentsContext(self, 'linter') as c:
         c.positional('modules', nargs='*', help='Space-separated list of modules or extensions to check.')

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'gitpython',
         'knack~=0.5.1',
         'mock',
-        'pytest',
+        'pytest>=3.6.0',
         'pytest-xdist',
         'requests',
         'tox'

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ setup(
         ":python_version<'3.0'": ['pylint~=1.9.2'],
         ":python_version>='3.0'": ['pylint~=2.0.0']
     },
-    package_data={'azdev.config': ['*.*', 'cli_pylintrc', 'ext_pylintrc']},
+    package_data={
+        'azdev.config': ['*.*', 'cli_pylintrc', 'ext_pylintrc'],
+        'azdev.operations.linter.rules': ['ci_exclusions.yml']
+    },
     include_package_data=True,
     entry_points={
         'console_scripts': ['azdev=azdev.__main__:main']


### PR DESCRIPTION
Work in progress.

- Standardizes behavior so `azdev test/style/linter` will, if nothing is provided, run on everything. Previously `azdev test` would not run any tests.
- Fix issue where `ci_exclusions.yml` were not found for the linter in CI mode.
- Splits `azdev verify version` into `azdev cli check-versions` and the much faster `azdev cli update-setup`. These will be used on the release branch. There are convenience argumetns in check-versions to effectively do the setup.py update without running an extra command.
- The check-version and update-setup commands allow you to let the versions in setup.py be pinned or unpinned.
- Fix #14. The module loading perf script now allows a certain number of modules to reach specific thresholds. This should avoid spurious CI failures. 


