### PR TITLE
Fix `azdev test --discover`

### DIFF
--- a/azdev/operations/tests/__init__.py
+++ b/azdev/operations/tests/__init__.py
@@ -220,7 +220,10 @@ def _discover_tests(profile):
     logger.info('\nExtensions: %s', ', '.join([name for name, _ in extensions]))
     for mod_name, mod_path in extensions:
         glob_pattern = os.path.normcase(os.path.join('{}*'.format(EXTENSION_PREFIX)))
-        filepath = glob.glob(os.path.join(mod_path, glob_pattern))[0]
+        try:
+            filepath = glob.glob(os.path.join(mod_path, glob_pattern))[0]
+        except IndexError:
+            logger.debug("No extension found at: %s", os.path.join(mod_path, glob_pattern))
         import_name = os.path.basename(filepath)
         mod_data = {
             'alt_name': os.path.split(filepath)[1],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
         'pytest-xdist',
         'pyyaml',
         'requests',
-        'tox'
+        'tox',
+        'wheel==0.30.0'
     ],
     extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2'],


### PR DESCRIPTION
Fixes #45.

Fix issue where virtual env in the extensions directory would could a stack trace on test discovery.