### PR TITLE
Add `azdev extension build` and `publish` commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/azdev.egg-info/*
 azdev.egg-info/
 .tox/
 *.idea
+pip-wheel-metadata/*

--- a/azdev/commands.py
+++ b/azdev/commands.py
@@ -48,17 +48,14 @@ def load_command_table(self, _):
         g.command('add', 'add_extension')
         g.command('remove', 'remove_extension')
         g.command('list', 'list_extensions')
-        # g.command('build', 'build_extension')
-        # g.command('publish', 'publish_extension')
+        g.command('build', 'build_extensions')
+        g.command('publish', 'publish_extensions')
         g.command('update-index', 'update_extension_index')
 
     with CommandGroup(self, 'extension repo', operation_group('extensions')) as g:
         g.command('add', 'add_extension_repo')
         g.command('remove', 'remove_extension_repo')
         g.command('list', 'list_extension_repos')
-
-    # with CommandGroup(self, 'group', operation_group('resource')) as g:
-    #     g.command('delete', 'delete_groups')
 
     # TODO: implement
     # with CommandGroup(self, operation_group('help')) as g:

--- a/azdev/config/ext.flake8
+++ b/azdev/config/ext.flake8
@@ -7,16 +7,8 @@ ignore =
     F401,  # imported but unused, too many violations, to be removed in the future
     F811,  # redefinition of unused, to be removed in the future
     C901   # code flow is too complex, too many violations, to be removed in the future
+    W504   # line break after binary operator effect on readability is subjective
 exclude = 
     */vendored_sdks
     docs
     scripts
-    ./src/eventgrid/azext_eventgrid/mgmt/eventgrid
-    ./src/botservice/azext_bot/botservice
-    ./src/dns/azext_dns/dns
-    ./src/managementgroups/azext_managementgroups/managementgroups
-    ./src/managementpartner/azext_managementpartner/managementpartner
-    ./src/rdbms_vnet/azext_rdbms_vnet/postgresql
-    ./src/rdbms_vnet/azext_rdbms_vnet/mysql
-    ./src/signalr/azext_signalr/signalr
-    ./src/subscription/azext_subscription/subscription

--- a/azdev/help.py
+++ b/azdev/help.py
@@ -169,6 +169,11 @@ helps['extension add'] = """
 """
 
 
+helps['extension build'] = """
+    short-summary: Construct a WHL file for one or more extensions.
+"""
+
+
 helps['extension remove'] = """
     short-summary: Make an extension no longer visible to the development environment.
     long-summary: This does not remove the extensions source code from your machine.
@@ -178,6 +183,12 @@ helps['extension remove'] = """
 helps['extension list'] = """
     short-summary: List what extensions are currently visible to your development environment.
 """
+
+
+helps['extension publish'] = """
+    short-summary: Build and publish an extension to a storage account.
+"""
+
 
 helps['extension update-index'] = """
     short-summary: Update the extensions index.json from a built WHL file.

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -5,14 +5,18 @@
 # -----------------------------------------------------------------------------
 
 from collections import OrderedDict
+import json
 import os
 import shutil
+import sys
 
 from knack.log import get_logger
+from knack.prompting import prompt_y_n
 from knack.util import CLIError
 
 from azdev.utilities import (
-    pip_cmd, display, get_ext_repo_paths, find_files, get_azure_config, get_env_config, require_azure_cli)
+    cmd, py_cmd, pip_cmd, display, get_ext_repo_paths, find_files, get_azure_config, get_env_config,
+    require_azure_cli, heading, subheading)
 
 logger = get_logger(__name__)
 
@@ -159,7 +163,7 @@ def list_extension_repos():
     return dev_sources.split(',') if dev_sources else dev_sources
 
 
-def update_extension_index(extension):
+def update_extension_index(extensions):
     import json
     import re
     import tempfile
@@ -175,43 +179,114 @@ def update_extension_index(extension):
 
     NAME_REGEX = r'.*/([^/]*)-\d+.\d+.\d+'
 
-    # Get extension WHL from URL
-    if not extension.endswith('.whl') or not extension.startswith('https:'):
-        raise ValueError('usage error: only URL to a WHL file currently supported.')
+    for extension in extensions:
+        # Get extension WHL from URL
+        if not extension.endswith('.whl') or not extension.startswith('https:'):
+            raise ValueError('usage error: only URL to a WHL file currently supported.')
 
-    # TODO: extend to consider other options
-    ext_path = extension
+        # TODO: extend to consider other options
+        ext_path = extension
 
-    # Extract the extension name
+        # Extract the extension name
+        try:
+            extension_name = re.findall(NAME_REGEX, ext_path)[0]
+            extension_name = extension_name.replace('_', '-')
+        except IndexError:
+            raise ValueError('unable to parse extension name')
+
+        # TODO: Update this!
+        extensions_dir = tempfile.mkdtemp()
+        ext_dir = tempfile.mkdtemp(dir=extensions_dir)
+        whl_cache_dir = tempfile.mkdtemp()
+        whl_cache = {}
+        ext_file = get_whl_from_url(ext_path, extension_name, whl_cache_dir, whl_cache)
+
+        with open(index_path, 'r') as infile:
+            curr_index = json.loads(infile.read())
+
+        entry = {
+            'downloadUrl': ext_path,
+            'sha256Digest': _get_sha256sum(ext_file),
+            'filename': ext_path.split('/')[-1],
+            'metadata': get_ext_metadata(ext_dir, ext_file, extension_name)
+        }
+
+        if extension_name not in curr_index['extensions'].keys():
+            logger.info("Adding '%s' to index...", extension_name)
+            curr_index['extensions'][extension_name] = [entry]
+        else:
+            logger.info("Updating '%s' in index...", extension_name)
+            curr_index['extensions'][extension_name].append(entry)
+
+        # update index and write back to file
+        with open(os.path.join(index_path), 'w') as outfile:
+            outfile.write(json.dumps(curr_index, indent=4, sort_keys=True))
+
+
+def build_extensions(extensions, dist_dir='dist'):
+    ext_paths = get_ext_repo_paths()
+    all_extensions = find_files(ext_paths, 'setup.py')
+
+    paths_to_build = []
+    for path in all_extensions:
+        folder = os.path.dirname(path)
+        long_name = os.path.basename(folder)
+        if long_name in extensions:
+            paths_to_build.append(folder)
+            extensions.remove(long_name)
+    # raise error if any extension wasn't found
+    if extensions:
+        raise CLIError('extension(s) not found: {}'.format(' '.join(extensions)))
+
+    for path in paths_to_build:
+        command = '{} bdist_wheel -b bdist -d {}'.format(os.path.join(path, 'setup.py'), dist_dir)
+        result = py_cmd(command, "Building extension '{}'...".format(path), is_module=False)
+        if result.error:
+            raise result.error  # pylint: disable=raising-bad-type
+
+
+def publish_extensions(extensions, storage_subscription=None, storage_account=None, storage_container=None,
+                       dist_dir='dist', update_index=False, yes=False):
+
+    heading('Publish Extensions')
+
+    require_azure_cli()
+
+    # rebuild the extensions
+    subheading('Building WHLs')
     try:
-        extension_name = re.findall(NAME_REGEX, ext_path)[0]
-        extension_name = extension_name.replace('_', '-')
-    except IndexError:
-        raise ValueError('unable to parse extension name')
+        shutil.rmtree(dist_dir)
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.error("Unable to clear folder '%s'. Error: %s", dist_dir, ex)
+    build_extensions(extensions, dist_dir=dist_dir)
 
-    extensions_dir = tempfile.mkdtemp()
-    ext_dir = tempfile.mkdtemp(dir=extensions_dir)
-    whl_cache_dir = tempfile.mkdtemp()
-    whl_cache = {}
-    ext_file = get_whl_from_url(ext_path, extension_name, whl_cache_dir, whl_cache)
+    whl_files = find_files(dist_dir, '*.whl')
+    uploaded_urls = []
 
-    with open(index_path, 'r') as infile:
-        curr_index = json.loads(infile.read())
+    subheading('Uploading WHLs')
+    for whl_path in whl_files:
+        whl_file = os.path.split(whl_path)[-1]
+        # check if extension already exists unless user opted not to
+        if not yes:
+            command = 'az storage blob exists --subscription {} --account-name {} -c {} -n {}'.format(
+                storage_subscription, storage_account, storage_container, whl_file)
+            exists = json.loads(cmd(command).result)['exists']
+            if exists:
+                if not prompt_y_n(
+                        "{} already exists. You may need to bump the extension version. Replace?".format(whl_file),
+                        default='n'):
+                    logger.warning("Skipping '%s'...", whl_file)
+                    continue
+        # upload the WHL file
+        command = 'az storage blob upload --subscription {} --account-name {} -c {} -n {} -f {}'.format(
+            storage_subscription, storage_account, storage_container, whl_file, os.path.abspath(whl_path))
+        cmd(command, "Uploading '{}'...".format(whl_file))
+        command = 'az storage blob url --subscription {} --account-name {} -c {} -n {} -otsv'.format(
+                storage_subscription, storage_account, storage_container, whl_file)
+        url = cmd(command).result
+        logger.info(url)
+        uploaded_urls.append(url)
 
-    entry = {
-        'downloadUrl': ext_path,
-        'sha256Digest': _get_sha256sum(ext_file),
-        'filename': ext_path.split('/')[-1],
-        'metadata': get_ext_metadata(ext_dir, ext_file, extension_name)
-    }
-
-    if extension_name not in curr_index['extensions'].keys():
-        logger.info("Adding '%s' to index...", extension_name)
-        curr_index['extensions'][extension_name] = [entry]
-    else:
-        logger.info("Updating '%s' in index...", extension_name)
-        curr_index['extensions'][extension_name].append(entry)
-
-    # update index and write back to file
-    with open(os.path.join(index_path), 'w') as outfile:
-        outfile.write(json.dumps(curr_index, indent=4, sort_keys=True))
+    if update_index:
+        subheading('Updating Index')
+        update_extension_index(uploaded_urls)

--- a/azdev/operations/extensions/util.py
+++ b/azdev/operations/extensions/util.py
@@ -23,7 +23,6 @@ WHEEL_INFO_RE = re.compile(
 
 def _get_extension_modname(ext_dir):
     # Modification of https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/extension.py#L153
-    print(list(os.listdir(ext_dir)))
     pos_mods = [n for n in os.listdir(ext_dir)
                 if n.startswith(EXTENSION_PREFIX) and os.path.isdir(os.path.join(ext_dir, n))]
     if len(pos_mods) != 1:
@@ -76,9 +75,7 @@ def get_whl_from_url(url, filename, tmp_dir, whl_cache=None):
         assert r.status_code == 200, "Request to {} failed with {}".format(url, r.status_code)
     except AssertionError:
         raise CLIError("unable to download (status code {}): {}".format(r.status_code, url))
-    print(filename)
     ext_file = os.path.join(tmp_dir, filename)
-    print(ext_file)
     with open(ext_file, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # ignore keep-alive new chunks

--- a/azdev/operations/extensions/util.py
+++ b/azdev/operations/extensions/util.py
@@ -23,6 +23,7 @@ WHEEL_INFO_RE = re.compile(
 
 def _get_extension_modname(ext_dir):
     # Modification of https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/extension.py#L153
+    print(list(os.listdir(ext_dir)))
     pos_mods = [n for n in os.listdir(ext_dir)
                 if n.startswith(EXTENSION_PREFIX) and os.path.isdir(os.path.join(ext_dir, n))]
     if len(pos_mods) != 1:
@@ -75,7 +76,9 @@ def get_whl_from_url(url, filename, tmp_dir, whl_cache=None):
         assert r.status_code == 200, "Request to {} failed with {}".format(url, r.status_code)
     except AssertionError:
         raise CLIError("unable to download (status code {}): {}".format(r.status_code, url))
+    print(filename)
     ext_file = os.path.join(tmp_dir, filename)
+    print(ext_file)
     with open(ext_file, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # ignore keep-alive new chunks

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -17,7 +17,7 @@ from azdev.operations.extensions import (
 from azdev.params import Flag
 from azdev.utilities import (
     display, heading, subheading, pip_cmd, find_file, get_path_table,
-    get_env_config_dir, get_env_config, require_virtual_env, get_azure_config)
+    get_azdev_config_dir, get_azdev_config, require_virtual_env, get_azure_config)
 
 logger = get_logger(__name__)
 
@@ -132,7 +132,7 @@ def _copy_config_files():
 
     config_mod = import_module('azdev.config')
     config_dir_path = config_mod.__dict__['__path__'][0]
-    dest_path = os.path.join(get_env_config_dir(), 'config_files')
+    dest_path = os.path.join(get_azdev_config_dir(), 'config_files')
     if os.path.exists(dest_path):
         rmtree(dest_path)
     copytree(config_dir_path, dest_path)
@@ -277,7 +277,7 @@ def setup(cli_path=None, ext_repo_path=None, ext=None):
     dev_sources = get_azure_config().get('extension', 'dev_sources', None)
 
     # save data to config files
-    config = get_env_config()
+    config = get_azdev_config()
     config.set_value('ext', 'repo_paths', dev_sources if dev_sources else '_NONE_')
     config.set_value('cli', 'repo_path', cli_path if cli_path else '_NONE_')
 

--- a/azdev/operations/style.py
+++ b/azdev/operations/style.py
@@ -14,7 +14,7 @@ from knack.util import CLIError, CommandResultItem
 
 from azdev.utilities import (
     display, heading, subheading, py_cmd, get_path_table, EXTENSION_PREFIX,
-    get_env_config_dir, require_azure_cli)
+    get_azdev_config_dir, require_azure_cli)
 
 
 logger = get_logger(__name__)
@@ -116,7 +116,7 @@ def _run_pylint(modules):
     def run(paths, rcfile, desc):
         if not paths:
             return None
-        config_path = os.path.join(get_env_config_dir(), 'config_files', rcfile)
+        config_path = os.path.join(get_azdev_config_dir(), 'config_files', rcfile)
         logger.info('Using rcfile file: %s', config_path)
         logger.info('Running on %s: %s', desc, ' '.join(paths))
         command = 'pylint {} --ignore vendored_sdks,privates --rcfile={} -j {}'.format(
@@ -138,7 +138,7 @@ def _run_pep8(modules):
     def run(paths, config_file, desc):
         if not paths:
             return None
-        config_path = os.path.join(get_env_config_dir(), 'config_files', config_file)
+        config_path = os.path.join(get_azdev_config_dir(), 'config_files', config_file)
         logger.info('Using config file: %s', config_path)
         logger.info('Running on %s: %s', desc, ' '.join(paths))
         command = 'flake8 --statistics --append-config={} {}'.format(

--- a/azdev/operations/tests/__init__.py
+++ b/azdev/operations/tests/__init__.py
@@ -20,7 +20,7 @@ from azdev.utilities import (
     cmd as raw_cmd, py_cmd, pip_cmd, find_file, IS_WINDOWS,
     ENV_VAR_TEST_LIVE,
     COMMAND_MODULE_PREFIX, EXTENSION_PREFIX,
-    make_dirs, get_env_config_dir,
+    make_dirs, get_azdev_config_dir,
     get_path_table, require_virtual_env)
 
 logger = get_logger(__name__)
@@ -32,7 +32,7 @@ def run_tests(tests, xml_path=None, discover=False, in_series=False,
     require_virtual_env()
 
     DEFAULT_RESULT_FILE = 'test_results.xml'
-    DEFAULT_RESULT_PATH = os.path.join(get_env_config_dir(), DEFAULT_RESULT_FILE)
+    DEFAULT_RESULT_PATH = os.path.join(get_azdev_config_dir(), DEFAULT_RESULT_FILE)
 
     from .pytest_runner import get_test_runner
 
@@ -285,7 +285,7 @@ def _discover_tests(profile):
 
 
 def _get_test_index(profile, discover):
-    config_dir = get_env_config_dir()
+    config_dir = get_azdev_config_dir()
     test_index_dir = os.path.join(config_dir, 'test_index')
     make_dirs(test_index_dir)
     test_index_path = os.path.join(test_index_dir, '{}.json'.format(profile))

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -21,6 +21,7 @@ def load_arguments(self, _):
     with ArgumentsContext(self, '') as c:
         c.argument('modules', options_list=['--modules', '-m'], nargs='+', help='Space-separated list of modules to check. Omit to check all.')
         c.argument('private', action='store_true', help='Target the private repo.')
+        c.argument('yes', options_list=['--yes', '-y'], action='store_true', help='Answer "yes" to all prompts.')
 
     with ArgumentsContext(self, 'setup') as c:
         c.argument('cli_path', options_list=['--cli', '-c'], nargs='?', const=Flag, help='Path to an existing Azure CLI repo. Omit value to search for the repo.')
@@ -64,7 +65,18 @@ def load_arguments(self, _):
     with ArgumentsContext(self, 'perf') as c:
         c.argument('runs', type=int, help='Number of runs to average performance over.')
 
-    for scope in ['extension add', 'extension remove']:
+    with ArgumentsContext(self, 'extension') as c:
+        c.argument('dist_dir', help='Name of a directory in which to save the resulting WHL files.')
+
+    with ArgumentsContext(self, 'extension publish') as c:
+        c.argument('update_index', action='store_true', help='Update the index.json file after publishing is complete.')
+
+    with ArgumentsContext(self, 'extension publish') as c:
+        c.argument('storage_account', help='Name of the storage account to publish to.', arg_group='Storage', configured_default='storage_account')
+        c.argument('storage_container', help='Name of the storage container to publish to.', arg_group='Storage', configured_default='storage_container')
+        c.argument('storage_subscription', help='Subscription ID of the storage account.', arg_group='Storage', configured_default='storage_subscription')
+
+    for scope in ['extension add', 'extension remove', 'extension build', 'extension publish']:
         with ArgumentsContext(self, scope) as c:
             c.positional('extensions', metavar='NAME', nargs='+', help='Space-separated list of extension names.')
 
@@ -73,11 +85,4 @@ def load_arguments(self, _):
             c.positional('repos', metavar='PATH', nargs='+', help='Space-separated list of paths to Git repositories.')
 
     with ArgumentsContext(self, 'extension update-index') as c:
-        c.positional('extension', metavar='URL', help='URL to an extension WHL file.')
-
-    with ArgumentsContext(self, 'group delete') as c:
-        c.argument('product', help='Value for tag `product` to mark for deletion.', arg_group='Tag')
-        c.argument('older_than', type=int, help='Minimum age (in hours) for tag `date` to mark for deletion.', arg_group='Tag')
-        c.argument('cause', help='Value for tag `cause` to mark for deletion.', arg_group='Tag')
-        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt.')
-        c.argument('prefixes', options_list=['--prefixes', '-p'], nargs='+', help='Space-separated list of prefixes to filter by.')
+        c.positional('extensions', nargs='+', metavar='URL', help='Space-separated list of URLs to extension WHL files.')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -16,6 +16,7 @@ class Flag(object):
     pass
 
 
+# pylint: disable=too-many-statements
 def load_arguments(self, _):
 
     with ArgumentsContext(self, '') as c:

--- a/azdev/utilities/__init__.py
+++ b/azdev/utilities/__init__.py
@@ -8,9 +8,7 @@ from .config import (
     get_azure_config,
     get_azure_config_dir,
     get_azdev_config,
-    get_azdev_config_dir,
-    get_env_config,
-    get_env_config_dir
+    get_azdev_config_dir
 )
 from .command import (
     call,
@@ -66,8 +64,6 @@ __all__ = [
     'get_azure_config',
     'get_azdev_config_dir',
     'get_azdev_config',
-    'get_env_config',
-    'get_env_config_dir',
     'ENV_VAR_TEST_MODULES',
     'ENV_VAR_TEST_LIVE',
     'ENV_VAR_VIRTUAL_ENV',

--- a/azdev/utilities/command.py
+++ b/azdev/utilities/command.py
@@ -57,12 +57,13 @@ def cmd(command, message=False, show_stderr=True, **kwargs):
         return CommandResultItem(err.output, exit_code=err.returncode, error=err)
 
 
-def py_cmd(command, message=False, show_stderr=True, **kwargs):
+def py_cmd(command, message=False, show_stderr=True, is_module=True, **kwargs):
     """ Run a script or command with Python.
 
     :param command: The arguments to run python with.
     :param message: A custom message to display, or True (bool) to use a default.
     :param show_stderr: On error, display the contents of STDERR.
+    :param is_module: Run a Python module as a script with -m.
     :param kwargs: Any kwargs supported by subprocess.Popen
     :returns: CommandResultItem object.
     """
@@ -70,7 +71,10 @@ def py_cmd(command, message=False, show_stderr=True, **kwargs):
     env_path = get_env_path()
     python_bin = sys.executable if not env_path else os.path.join(
         env_path, 'Scripts' if sys.platform == 'win32' else 'bin', 'python')
-    command = '{} -m {}'.format(python_bin, command)
+    if is_module:
+        command = '{} -m {}'.format(python_bin, command)
+    else:
+        command = '{} {}'.format(python_bin, command)
     return cmd(command, message, show_stderr, **kwargs)
 
 

--- a/azdev/utilities/config.py
+++ b/azdev/utilities/config.py
@@ -7,7 +7,6 @@
 import os
 
 from knack.config import CLIConfig
-from knack.util import CLIError
 
 
 def get_azdev_config():
@@ -18,27 +17,17 @@ def get_azure_config():
     return CLIConfig(config_dir=get_azure_config_dir(), config_env_var_prefix='AZURE')
 
 
-def get_env_config():
-    return CLIConfig(config_dir=get_env_config_dir(), config_env_var_prefix='AZDEV')
-
-
 def get_azdev_config_dir():
     """ Returns the user's .azdev directory. """
-    return os.getenv('AZDEV_CONFIG_DIR', None) or os.path.expanduser(os.path.join('~', '.azdev'))
+    from azdev.utilities import get_env_path
+    env_name = None
+    _, env_name = os.path.splitdrive(get_env_path())
+    azdev_dir = os.getenv('AZDEV_CONFIG_DIR', None) or os.path.expanduser(os.path.join('~', '.azdev'))
+    if not env_name:
+        return azdev_dir
+    return os.path.join(azdev_dir, 'env_config') + env_name
 
 
 def get_azure_config_dir():
     """ Returns the user's Azure directory. """
     return os.getenv('AZURE_CONFIG_DIR', None) or os.path.expanduser(os.path.join('~', '.azure'))
-
-
-def get_env_config_dir():
-    from azdev.utilities import get_env_path, require_virtual_env
-    require_virtual_env()
-    env_name = None
-    _, env_name = os.path.splitdrive(get_env_path())
-    if not env_name:
-        raise CLIError('An active Python virtual environment is required.')
-    azdev_config_dir = get_azdev_config_dir()
-    config_dir = os.path.join(azdev_config_dir, 'env_config') + env_name
-    return config_dir

--- a/azdev/utilities/path.py
+++ b/azdev/utilities/path.py
@@ -42,9 +42,9 @@ def get_cli_repo_path():
     :returns: Path (str) to Azure CLI repo.
     """
     from configparser import NoSectionError
-    from .config import get_env_config
+    from .config import get_azdev_config
     try:
-        return get_env_config().get('cli', 'repo_path')
+        return get_azdev_config().get('cli', 'repo_path')
     except NoSectionError:
         raise CLIError('Unable to retrieve CLI repo path from config. Please run `azdev setup`.')
 
@@ -55,9 +55,9 @@ def get_ext_repo_paths():
     :returns: Path (str) to Azure CLI dev extension repos.
     """
     from configparser import NoSectionError
-    from .config import get_env_config
+    from .config import get_azdev_config
     try:
-        return get_env_config().get('ext', 'repo_paths').split(',')
+        return get_azdev_config().get('ext', 'repo_paths').split(',')
     except NoSectionError:
         raise CLIError('Unable to retrieve extensions repo path from config. Please run `azdev setup`.')
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'flake8',
         'futures',
         'gitpython',
-        'knack>=0.5.3',
+        'knack>=0.5.4',
         'mock',
         'pytest>=3.6.0',
         'pytest-xdist',


### PR DESCRIPTION
Closes #58.  The user can configure defaults for the storage account, container and subscription.

```
(env) Traviss-MacBook-Pro-2:github travisprescott$ azdev extension publish -h

Command
    azdev extension publish : Build and publish an extension to a storage account.

Arguments
    --dist-dir             : Name of a directory in which to save the resulting WHL files.  Default:
                             dist.
    --update-index         : Update the index.json file after publishing is complete.
    --yes -y               : Answer "yes" to all prompts.

Positional
    NAME                   : Space-separated list of extension names.

Storage Arguments
    --storage-account      : Name of the storage account to publish to.
    --storage-container    : Name of the storage container to publish to.
    --storage-subscription : Subscription ID of the storage account.
```