### PR TITLE
Bump min pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'gitpython',
         'knack~=0.6.1',
         'mock',
-        'pytest>=3.6.0',
+        'pytest~=4.4.0',
         'pytest-xdist',
         'pyyaml',
         'requests',


### PR DESCRIPTION
Fix #77.

Bump to ~=4.4.0 since this is what pytest-xdist requires.