### PR TITLE
Update setup command to use platform appropriate requirements.txt file.

### DIFF
--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -77,7 +77,7 @@ def _install_cli(cli_path):
     local_distributables = ' '.join(
         root
         for root, dirs, files in os.walk(src_path)
-        if 'setup.py' in files and os.path.basename(root) in ['azure-cli'])
+        if 'setup.py' in files)
 
     python_major_version = sys.version_info[0]
 

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -85,7 +85,7 @@ def _install_cli(cli_path):
         requirements_file = "{}/src/azure-cli/requirements.py{}.Darwin.txt".format(cli_path, python_major_version)
     elif sys.platform.startswith('win32'):
         requirements_file = "{}/src/azure-cli/requirements.py{}.Windows.txt".format(cli_path, python_major_version)
-    elif sys.platform.startwith('linux'):
+    elif sys.platform.startswith('linux'):
         requirements_file = "{}/src/azure-cli/requirements.py{}.Linux.txt".format(cli_path, python_major_version)
 
     if requirements_file:


### PR DESCRIPTION
This will ensure that folks doing development have the same version of the dependencies on their local machines that we will eventually distribute the CLI with.