### PR TITLE
Add severity to linter rules. Add new linter rules.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ===============
 
+0.1.5
+++++++
+* Linter Rule Severity: Rules now have an associated severity level. Only high severity rules should be run in CI. All previous rules are annotated as HIGH severity.
+
+   * Note: HIGH severity rules are egregious and should generally be fixed, not excluded. LOW severity rules tend to be informational, and might raise false positives. Exclude them via `linter_exclusions.yml` in the CLI.
+
+* `azdev linter`: Expose `--min-severity` to support idea of rule severity. New HIGH, MEDIUM and LOW severity rules have also been added.
+
+
 0.1.4
 ++++++
 * `azdev linter`: Fix issue with help example rule.

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 
 
 # pylint:disable=too-many-locals
-def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None, severity=None):
+def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None, min_severity=None):
 
     require_azure_cli()
 
@@ -35,9 +35,9 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None, se
     heading('CLI Linter')
 
     # process severity option
-    if severity:
+    if min_severity:
         try:
-            severity = LinterSeverity.get_linter_severity(severity)
+            min_severity = LinterSeverity.get_linter_severity(min_severity)
         except ValueError:
             valid_choices = linter_severity_choices()
             raise CLIError("Please specify a valid linter severity. It should be one of: {}"
@@ -104,7 +104,7 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None, se
                                    loaded_help=loaded_help,
                                    exclusions=exclusions,
                                    rule_inclusions=rules,
-                                   use_ci_exclusions=ci_exclusions, severity=severity)
+                                   use_ci_exclusions=ci_exclusions, min_severity=min_severity)
 
     subheading('Results')
     logger.info('Running linter: %i commands, %i help entries',

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -9,8 +9,6 @@ import sys
 import time
 import yaml
 
-from knack.arguments import ignore_type, ArgumentsContext
-from knack import events
 from knack.help_files import helps
 from knack.log import get_logger
 from knack.util import CLIError
@@ -18,7 +16,7 @@ from knack.util import CLIError
 from azdev.utilities import (
     heading, subheading, display, get_path_table, require_azure_cli)
 
-from .linter import LinterManager, LinterScope, RuleError
+from .linter import LinterManager, LinterScope, RuleError, LinterSeverity
 from .util import filter_modules
 
 
@@ -26,7 +24,7 @@ logger = get_logger(__name__)
 
 
 # pylint:disable=too-many-locals
-def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None):
+def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None, severity=None):
 
     require_azure_cli()
 
@@ -35,6 +33,15 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None):
         get_all_help, create_invoker_and_load_cmds_and_args)
 
     heading('CLI Linter')
+
+    # process severity option
+    if severity:
+        try:
+            severity = LinterSeverity.get_linter_severity(severity)
+        except ValueError:
+            valid_choices = linter_severity_choices()
+            raise CLIError("Please specify a valid linter severity. It should be one of: {}"
+                           .format(", ".join(valid_choices)))
 
     # needed to remove helps from azdev
     azdev_helps = helps.copy()
@@ -97,7 +104,7 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None):
                                    loaded_help=loaded_help,
                                    exclusions=exclusions,
                                    rule_inclusions=rules,
-                                   use_ci_exclusions=ci_exclusions)
+                                   use_ci_exclusions=ci_exclusions, severity=severity)
 
     subheading('Results')
     logger.info('Running linter: %i commands, %i help entries',
@@ -108,3 +115,7 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None):
         run_command_groups=not rule_types or 'command_groups'in rule_types,
         run_help_files_entries=not rule_types or 'help_entries' in rule_types)
     sys.exit(exit_code)
+
+
+def linter_severity_choices():
+    return [str(severity.name).lower() for severity in LinterSeverity]

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -25,15 +25,10 @@ class LinterSeverity(Enum):
     LOW = 0
 
     @staticmethod
-    def get_linter_severity(severity_name_or_value):
+    def get_linter_severity(severity_name):
         for severity in LinterSeverity:
-            if severity_name_or_value.lower() == severity.name.lower():
+            if severity_name.lower() == severity.name.lower():
                 return severity
-            try:
-                if int(severity_name_or_value) == severity.value:
-                    return severity
-            except ValueError:
-                continue
         raise ValueError("Severity must be a valid linter severity name or value.")
 
     @staticmethod

--- a/azdev/operations/linter/rule_decorators.py
+++ b/azdev/operations/linter/rule_decorators.py
@@ -15,8 +15,9 @@ class AbstractRule(object):
     def __init__(self, severity):
         if severity not in LinterSeverity:
             raise CLIError("A {} rule has an invalid severity. Received {}; expected one of: {}"
-                           .format(str(self.__class__), severity,list(LinterSeverity)))
+                           .format(str(self.__class__), severity, list(LinterSeverity)))
         self.severity = severity
+
 
 # help_file_entry_rule
 class HelpFileEntryRule(AbstractRule):
@@ -24,11 +25,13 @@ class HelpFileEntryRule(AbstractRule):
     def __call__(self, func):
         return _get_decorator(func, 'help_file_entries', 'Help-Entry: `{}`', self.severity)
 
+
 # command_rule
 class CommandRule(AbstractRule):
 
     def __call__(self, func):
         return _get_decorator(func, 'commands', 'Command: `{}`', self.severity)
+
 
 # command_group_rule
 class CommandGroupRule(AbstractRule):
@@ -93,6 +96,6 @@ def _create_violation_msg(ex, format_string, *format_args):
 def _linter_severity_is_applicable(linter_severity, rule_severity, rule_name):
     if linter_severity.value > rule_severity.value:
         _logger.info("Skipping rule %s, because its severity '%s' is lower than the linter's severity '%s'.",
-        rule_name, rule_severity.name, linter_severity)
+                     rule_name, rule_severity.name, linter_severity)
         return False
     return True

--- a/azdev/operations/linter/rule_decorators.py
+++ b/azdev/operations/linter/rule_decorators.py
@@ -4,54 +4,83 @@
 # license information.
 # -----------------------------------------------------------------------------
 
-from .linter import RuleError
+from knack.log import get_logger
+from knack.util import CLIError
+from .linter import RuleError, LinterSeverity
+_logger = get_logger(__name__)
 
 
-def help_file_entry_rule(func):
-    return _get_decorator(func, 'help_file_entries', 'Help-Entry: `{}`')
+class AbstractRule(object):
+
+    def __init__(self, severity):
+        if severity not in LinterSeverity:
+            raise CLIError("A {} rule has an invalid severity. Received {}; expected one of: {}"
+                           .format(str(self.__class__), severity,list(LinterSeverity)))
+        self.severity = severity
+
+# help_file_entry_rule
+class HelpFileEntryRule(AbstractRule):
+
+    def __call__(self, func):
+        return _get_decorator(func, 'help_file_entries', 'Help-Entry: `{}`', self.severity)
+
+# command_rule
+class CommandRule(AbstractRule):
+
+    def __call__(self, func):
+        return _get_decorator(func, 'commands', 'Command: `{}`', self.severity)
+
+# command_group_rule
+class CommandGroupRule(AbstractRule):
+
+    def __call__(self, func):
+        return _get_decorator(func, 'command_groups', 'Command-Group: `{}`', self.severity)
 
 
-def command_rule(func):
-    return _get_decorator(func, 'commands', 'Command: `{}`')
+# parameter_rule
+class ParameterRule(AbstractRule):
+
+    def __call__(self, func):
+        def add_to_linter(linter_manager):
+            def wrapper():
+                linter = linter_manager.linter
+                linter_severity = linter_manager.severity
+
+                if _linter_severity_is_applicable(linter_severity, self.severity, func.__name__):
+                    for command_name in linter.commands:
+                        for parameter_name in linter.get_command_parameters(command_name):
+                            exclusion_parameters = linter_manager.exclusions.get(command_name, {}).get('parameters', {})
+                            exclusions = exclusion_parameters.get(parameter_name, {}).get('rule_exclusions', [])
+                            if func.__name__ not in exclusions:
+                                try:
+                                    func(linter, command_name, parameter_name)
+                                except RuleError as ex:
+                                    linter_manager.mark_rule_failure()
+                                    yield _create_violation_msg(ex, 'Parameter: {}, `{}`',
+                                                                command_name, parameter_name)
+
+            linter_manager.add_rule('params', func.__name__, wrapper, self.severity)
+        add_to_linter.linter_rule = True
+        return add_to_linter
 
 
-def command_group_rule(func):
-    return _get_decorator(func, 'command_groups', 'Command-Group: `{}`')
-
-
-def parameter_rule(func):
+def _get_decorator(func, rule_group, print_format, severity):
     def add_to_linter(linter_manager):
         def wrapper():
             linter = linter_manager.linter
-            for command_name in linter.commands:
-                for parameter_name in linter.get_command_parameters(command_name):
-                    exclusion_parameters = linter_manager.exclusions.get(command_name, {}).get('parameters', {})
-                    exclusions = exclusion_parameters.get(parameter_name, {}).get('rule_exclusions', [])
+            linter_severity = linter_manager.severity
+
+            if _linter_severity_is_applicable(linter_severity, severity, func.__name__):
+                for iter_entity in getattr(linter, rule_group):
+                    exclusions = linter_manager.exclusions.get(iter_entity, {}).get('rule_exclusions', [])
                     if func.__name__ not in exclusions:
                         try:
-                            func(linter, command_name, parameter_name)
+                            func(linter, iter_entity)
                         except RuleError as ex:
                             linter_manager.mark_rule_failure()
-                            yield _create_violation_msg(ex, 'Parameter: {}, `{}`',
-                                                        command_name, parameter_name)
-        linter_manager.add_rule('params', func.__name__, wrapper)
-    add_to_linter.linter_rule = True
-    return add_to_linter
+                            yield _create_violation_msg(ex, print_format, iter_entity)
 
-
-def _get_decorator(func, rule_group, print_format):
-    def add_to_linter(linter_manager):
-        def wrapper():
-            linter = linter_manager.linter
-            for iter_entity in getattr(linter, rule_group):
-                exclusions = linter_manager.exclusions.get(iter_entity, {}).get('rule_exclusions', [])
-                if func.__name__ not in exclusions:
-                    try:
-                        func(linter, iter_entity)
-                    except RuleError as ex:
-                        linter_manager.mark_rule_failure()
-                        yield _create_violation_msg(ex, print_format, iter_entity)
-        linter_manager.add_rule(rule_group, func.__name__, wrapper)
+        linter_manager.add_rule(rule_group, func.__name__, wrapper, severity)
     add_to_linter.linter_rule = True
     return add_to_linter
 
@@ -59,3 +88,11 @@ def _get_decorator(func, rule_group, print_format):
 def _create_violation_msg(ex, format_string, *format_args):
     violation_string = format_string.format(*format_args)
     return '    {} - {}'.format(violation_string, ex)
+
+
+def _linter_severity_is_applicable(linter_severity, rule_severity, rule_name):
+    if linter_severity.value > rule_severity.value:
+        _logger.info("Skipping rule %s, because its severity '%s' is lower than the linter's severity '%s'.",
+        rule_name, rule_severity.name, linter_severity)
+        return False
+    return True

--- a/azdev/operations/linter/rules/ci_exclusions.yml
+++ b/azdev/operations/linter/rules/ci_exclusions.yml
@@ -10,4 +10,5 @@ no_ids_for_list_commands:
 - sql
 faulty_help_example_parameters_rule:
 - find
-...
+
+... # end of document

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -62,4 +62,4 @@ def require_wait_command_if_no_wait(linter, command_group_name):
     # otherwise there is no wait command. If a command in this group has --no-wait, then error out.
     for cmd in group_command_names:
         if linter._command_loader.command_table[cmd].supports_no_wait:
-            raise RuleError("Group does not have a 'wait' command, yet {} exposes '--no-wait'".format(cmd))
+            raise RuleError("Group does not have a 'wait' command, yet '{}' exposes '--no-wait'".format(cmd))

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -4,18 +4,18 @@
 # license information.
 # -----------------------------------------------------------------------------
 
-from ..rule_decorators import command_group_rule
-from ..linter import RuleError
+from ..rule_decorators import CommandGroupRule
+from ..linter import RuleError, LinterSeverity
 
 
-@command_group_rule
+@CommandGroupRule(LinterSeverity.HIGH)
 def missing_group_help(linter, command_group_name):
     if not linter.get_command_group_help(command_group_name) and not linter.command_group_expired(command_group_name) \
             and command_group_name != '':
         raise RuleError('Missing help')
 
 
-@command_group_rule
+@CommandGroupRule(LinterSeverity.HIGH)
 def expired_command_group(linter, command_group_name):
     if linter.command_group_expired(command_group_name):
         raise RuleError("Deprecated command group is expired and should be removed.")

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -19,3 +19,26 @@ def missing_group_help(linter, command_group_name):
 def expired_command_group(linter, command_group_name):
     if linter.command_group_expired(command_group_name):
         raise RuleError("Deprecated command group is expired and should be removed.")
+
+@CommandGroupRule(LinterSeverity.HIGH)
+def command_loader_has_no_resource_type(linter, command_group_name):
+    # This is a group rule because command loaders apply to multiple commands in one or more groups.
+    # Detecting violations per group is less verbose in the case of a rule violation, instead of per command.
+
+    # first find all commands under this group and their loaders.
+    cmd_loaders = {cmd: loaders for cmd, loaders in linter._command_loader.cmd_to_loader_map.items()
+                   if cmd.startswith(command_group_name)}
+
+    # ensure that every command has a single associated loader.
+    for cmd, loaders in cmd_loaders.items():
+        if len(loaders) != 1:
+            raise RuleError("Error: expected that command {} is associated with only one command loader. "
+                            "However, it is associated with {}".format(cmd, len(loaders)))
+
+    cmd_loaders = {loaders[0] for loaders in cmd_loaders.values()}
+
+    for loader in cmd_loaders:
+        if 'resource_type' not in loader.module_kwargs:
+            cls_str = loader.__class__.__name__
+            raise RuleError("Every command loader must have an associated 'resource_type'. {} does not. "
+                            "For more information see the 'authoring_commands.md' doc in the CLI repo.".format(cls_str))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -7,6 +7,7 @@
 from ..rule_decorators import CommandRule
 from ..linter import RuleError, LinterSeverity
 
+
 @CommandRule(LinterSeverity.HIGH)
 def missing_command_help(linter, command_name):
     if not linter.get_command_help(command_name) and not linter.command_expired(command_name):

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -24,3 +24,13 @@ def no_ids_for_list_commands(linter, command_name):
 def expired_command(linter, command_name):
     if linter.command_expired(command_name):
         raise RuleError('Deprecated command is expired and should be removed.')
+
+@CommandRule(LinterSeverity.HIGH)
+def update_commands_support_generic_update(linter, command_name):
+    if command_name.split()[-1].lower() == "update":
+        gen_update_params_set = {'properties_to_set', 'properties_to_add', 'properties_to_remove', 'force_string'}
+
+        all_params_set = set(linter._command_loader.command_table[command_name].keys())
+
+        if not gen_update_params_set <= all_params_set:
+            raise RuleError("Update command does not have generic update arguments.")

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -30,7 +30,7 @@ def update_commands_support_generic_update(linter, command_name):
     if command_name.split()[-1].lower() == "update":
         gen_update_params_set = {'properties_to_set', 'properties_to_add', 'properties_to_remove', 'force_string'}
 
-        all_params_set = set(linter._command_loader.command_table[command_name].keys())
+        all_params_set = set(linter._command_loader.command_table[command_name].arguments.keys())
 
         if not gen_update_params_set <= all_params_set:
             raise RuleError("Update command does not have generic update arguments.")

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -34,3 +34,13 @@ def update_commands_support_generic_update(linter, command_name):
 
         if not gen_update_params_set <= all_params_set:
             raise RuleError("Update command does not have generic update arguments.")
+
+
+@CommandRule(LinterSeverity.LOW)
+def group_delete_commands_should_confirm(linter, command_name):
+    # We cannot detect from cmd table etc whether a delete command deletes a collection, group or set of resources.
+    # so warn users for every delete command.
+
+    if command_name.split()[-1].lower() == "delete":
+        if 'yes' not in linter._parameters[command_name]:
+            raise RuleError("If this command deletes a collection, or group of resources. Please make sure to ask for confirmation.")

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -4,23 +4,22 @@
 # license information.
 # -----------------------------------------------------------------------------
 
-from ..rule_decorators import command_rule
-from ..linter import RuleError
+from ..rule_decorators import CommandRule
+from ..linter import RuleError, LinterSeverity
 
-
-@command_rule
+@CommandRule(LinterSeverity.HIGH)
 def missing_command_help(linter, command_name):
     if not linter.get_command_help(command_name) and not linter.command_expired(command_name):
         raise RuleError('Missing help')
 
 
-@command_rule
+@CommandRule(LinterSeverity.HIGH)
 def no_ids_for_list_commands(linter, command_name):
     if command_name.split()[-1] == 'list' and 'ids' in linter.get_command_parameters(command_name):
         raise RuleError('List commands should not expose --ids argument')
 
 
-@command_rule
+@CommandRule(LinterSeverity.HIGH)
 def expired_command(linter, command_name):
     if linter.command_expired(command_name):
         raise RuleError('Deprecated command is expired and should be removed.')

--- a/azdev/operations/linter/rules/help_rules.py
+++ b/azdev/operations/linter/rules/help_rules.py
@@ -11,8 +11,8 @@ import mock
 
 from knack.log import get_logger
 
-from ..rule_decorators import help_file_entry_rule
-from ..linter import RuleError
+from ..rule_decorators import HelpFileEntryRule
+from ..linter import RuleError, LinterSeverity
 from ..util import LinterError
 
 # pylint: disable=anomalous-backslash-in-string
@@ -28,13 +28,13 @@ _CMD_SUB_2 = re.compile("`\s*" + "(" + _az_pattern + ")" + "`")  # noqa: W605
 logger = get_logger(__name__)
 
 
-@help_file_entry_rule
+@HelpFileEntryRule(LinterSeverity.HIGH)
 def unrecognized_help_entry_rule(linter, help_entry):
     if help_entry not in linter.commands and help_entry not in linter.command_groups:
         raise RuleError('Not a recognized command or command-group')
 
 
-@help_file_entry_rule
+@HelpFileEntryRule(LinterSeverity.HIGH)
 def faulty_help_type_rule(linter, help_entry):
     if linter.get_help_entry_type(help_entry) != 'group' and help_entry in linter.command_groups:
         raise RuleError('Command-group should be of help-type `group`')
@@ -42,7 +42,7 @@ def faulty_help_type_rule(linter, help_entry):
         raise RuleError('Command should be of help-type `command`')
 
 
-@help_file_entry_rule
+@HelpFileEntryRule(LinterSeverity.HIGH)
 def unrecognized_help_parameter_rule(linter, help_entry):
     if help_entry not in linter.commands:
         return
@@ -56,7 +56,7 @@ def unrecognized_help_parameter_rule(linter, help_entry):
         raise RuleError('The following parameter help names are invalid: {}'.format(' | '.join(violations)))
 
 
-@help_file_entry_rule
+@HelpFileEntryRule(LinterSeverity.HIGH)
 def faulty_help_example_rule(linter, help_entry):
     violations = []
     for index, example in enumerate(linter.get_help_entry_examples(help_entry)):
@@ -68,7 +68,7 @@ def faulty_help_example_rule(linter, help_entry):
             ' | '.join(violations)))
 
 
-@help_file_entry_rule
+@HelpFileEntryRule(LinterSeverity.HIGH)
 def faulty_help_example_parameters_rule(linter, help_entry):
     parser = linter.command_parser
     violations = []

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -73,7 +73,7 @@ def no_positional_parameters(linter, command_name, parameter_name):
     options_list = parameter.get('options_list', [])
 
     if not options_list:
-        raise RuleError("CLI commands should have optional parameters instead of positional parameters "
+        raise RuleError("CLI commands should have optional parameters instead of positional parameters. "
                         "However parameter '{}' in command '{}' is a positional."
                         .format(parameter_name, command_name))
 
@@ -85,5 +85,59 @@ def no_parameter_defaults_for_update_commands(linter, command_name, parameter_na
         parameter = linter._command_loader.command_table[command_name].arguments[parameter_name].type.settings
         default_val = parameter.get('default')
         if default_val:
-            raise RuleError("Update commands should not have parameters with default values. \n\t{} in {} has a "
+            raise RuleError("Update commands should not have parameters with default values. {} in {} has a "
                             "default value of '{}'".format(parameter_name, command_name, default_val))
+
+
+@ParameterRule(LinterSeverity.MEDIUM)
+def no_required_location_param(linter, command_name, parameter_name):
+    # Location parameters should not be required
+
+    has_resource_group = "resource_group_name" in linter._parameters[command_name]
+    is_location_param = (parameter_name.lower() == "location" or parameter_name.endswith("location"))
+
+    if has_resource_group and is_location_param:
+        parameter = linter._command_loader.command_table[command_name].arguments[parameter_name].type.settings
+        is_required = parameter.get('required')
+
+        if is_required:
+            raise RuleError("Location parameters should not be required. However, {} in {} should is required. "
+                            "Please make it optional and default to the location of the resource group."
+                            .format(parameter_name, command_name))
+
+
+@ParameterRule(LinterSeverity.LOW)
+def id_params_only_for_guid(linter, command_name, parameter_name):
+    # Check if the parameter is an id param, except for '--ids'. If so, attempt to figure out if
+    # it is a resource id parametere. This check can lead to false positives, which is why it is a low severity check.
+    # Its aim is to guide reviewers and developers.
+
+    def _help_contains_queries(help_strings, queries):
+        a_query_is_in_a_str = next((True for help_str in help_strings
+                                    for query in queries if query.lower() in help_str.lower()), False)
+        return a_query_is_in_a_str
+
+    parameter = linter._command_loader.command_table[command_name].arguments[parameter_name].type.settings
+    options_list = parameter.get('options_list', [])
+    queries = ["resource id", "arm id"]
+    is_id_param = False
+
+    # first find out if an option ends with id.
+    for opt in options_list:
+        if isinstance(opt, Deprecated):
+            return
+
+        id_opts = [opt.endswith('-id'), opt.endswith('-ids')]
+
+        if any(id_opts) and opt != "--ids":
+            is_id_param = True
+
+    # if an option is an id param, check if the help text makes reference to 'resource id' etc. This could lead to fa
+    if is_id_param:
+        help_obj = linter._loaded_help[command_name]
+        help_param = next((help_param_obj for help_param_obj in help_obj.parameters
+                               if help_param_obj == " ".join(options_list)), None)
+
+        if help_param and _help_contains_queries([help_param.short_summary, help_param.long_summary], queries):
+            raise RuleError("An option {} ends with '-id'. Arguments ending with '-id' "
+                            "must be guids/uuids and not resource ids.", options_list)

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -4,30 +4,30 @@
 # license information.
 # -----------------------------------------------------------------------------
 
-from ..rule_decorators import parameter_rule
-from ..linter import RuleError
+from ..rule_decorators import ParameterRule
+from ..linter import RuleError, LinterSeverity
 
 
-@parameter_rule
+@ParameterRule(LinterSeverity.HIGH)
 def missing_parameter_help(linter, command_name, parameter_name):
     if not linter.get_parameter_help(command_name, parameter_name) and not linter.command_expired(command_name):
         raise RuleError('Missing help')
 
 
-@parameter_rule
+@ParameterRule(LinterSeverity.HIGH)
 def expired_parameter(linter, command_name, parameter_name):
     if linter.parameter_expired(command_name, parameter_name):
         raise RuleError('Deprecated parameter is expired and should be removed.')
 
 
-@parameter_rule
+@ParameterRule(LinterSeverity.HIGH)
 def expired_option(linter, command_name, parameter_name):
     expired_options = linter.option_expired(command_name, parameter_name)
     if expired_options:
         raise RuleError("Deprecated options '{}' are expired and should be removed.".format(', '.join(expired_options)))
 
 
-@parameter_rule
+@ParameterRule(LinterSeverity.HIGH)
 def bad_short_option(linter, command_name, parameter_name):
     from knack.deprecation import Deprecated
     bad_options = []

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -45,7 +45,7 @@ def bad_short_option(linter, command_name, parameter_name):
 
 
 @ParameterRule(LinterSeverity.HIGH)
-def parameter_ends_in_resource_group(linter, command_name, parameter_name):
+def parameter_should_not_end_in_resource_group(linter, command_name, parameter_name):
     parameter = linter._command_loader.command_table[command_name].arguments[parameter_name].type.settings
     options_list = parameter.get('options_list', [])
     bad_options = []

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -55,7 +55,9 @@ def parameter_should_not_end_in_resource_group(linter, command_name, parameter_n
             # we don't care if deprecated options are "bad options" since this is the
             # mechanism by which we get rid of them
             continue
-        if any([opt.endswith('resource-group'), opt.endswith('resourcegroup')]) and opt != "--resource-group":
+
+        bad_opts = [opt.endswith('resource-group'), opt.endswith('resourcegroup'), opt.endswith("resource-group-name")]
+        if any(bad_opts) and opt != "--resource-group":
             bad_options.append(opt)
 
     if bad_options:
@@ -74,3 +76,14 @@ def no_positional_parameters(linter, command_name, parameter_name):
         raise RuleError("CLI commands should have optional parameters instead of positional parameters "
                         "However parameter '{}' in command '{}' is a positional."
                         .format(parameter_name, command_name))
+
+
+
+@ParameterRule(LinterSeverity.HIGH)
+def no_parameter_defaults_for_update_commands(linter, command_name, parameter_name):
+    if command_name.split()[-1].lower() == "update":
+        parameter = linter._command_loader.command_table[command_name].arguments[parameter_name].type.settings
+        default_val = parameter.get('default')
+        if default_val:
+            raise RuleError("Update commands should not have parameters with default values. \n\t{} in {} has a "
+                            "default value of '{}'".format(parameter_name, command_name, default_val))

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -10,6 +10,7 @@ import argparse
 from knack.arguments import ArgumentsContext
 
 from azdev.completer import get_test_completion
+from azdev.operations.linter import linter_severity_choices
 
 
 class Flag(object):
@@ -61,6 +62,8 @@ def load_arguments(self, _):
         c.argument('rules', options_list=['--rules', '-r'], nargs='+', help='Space-separated list of rules to run. Omit to run all rules.')
         c.argument('rule_types', options_list=['--rule-types', '-t'], nargs='+', choices=['params', 'commands', 'command_groups', 'help_entries'], help='Space-separated list of rule types to run. Omit to run all.')
         c.argument('ci_exclusions', action='store_true', help='Force application of CI exclusions list when run locally.')
+        c.argument('severity', choices=linter_severity_choices(),
+                   help='The minimum severity level to run the linter on. For example, specifying "medium" runs linter rules that have "high" or "medium" severity. However, specifying "low" runs the linter on every rule, regardless of severity. Defaults to "high".')
 
     with ArgumentsContext(self, 'perf') as c:
         c.argument('runs', type=int, help='Number of runs to average performance over.')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -62,7 +62,7 @@ def load_arguments(self, _):
         c.argument('rules', options_list=['--rules', '-r'], nargs='+', help='Space-separated list of rules to run. Omit to run all rules.')
         c.argument('rule_types', options_list=['--rule-types', '-t'], nargs='+', choices=['params', 'commands', 'command_groups', 'help_entries'], help='Space-separated list of rule types to run. Omit to run all.')
         c.argument('ci_exclusions', action='store_true', help='Force application of CI exclusions list when run locally.')
-        c.argument('severity', choices=linter_severity_choices(),
+        c.argument('min_severity', choices=linter_severity_choices(),
                    help='The minimum severity level to run the linter on. For example, specifying "medium" runs linter rules that have "high" or "medium" severity. However, specifying "low" runs the linter on every rule, regardless of severity. Defaults to "high".')
 
     with ArgumentsContext(self, 'perf') as c:

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     ],
     extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2', 'futures'],
+        ":python_version<'3.4'": ['enum34'],
         ":python_version>='3.0'": ['pylint==2.3.0']
     },
     package_data={


### PR DESCRIPTION
- [ ] Add --severity which specifies the minimum severity of the linter. Rules with lower severity will not be executed. This way we can distinguish between high priority rule infractions and lower priority infractions that could be helpful in command reviews. See `--severity` help text for `azdev linter`
- [x] Add `parameter_should_not_end_with_resource_group` rule - the only param that should end in `resource-group` is `--resource-group` --- **severity high**
- [x] Add `no_positional_parameters` rule - we frown on positional params in the CLI. --- **severity high**
- [x] Add `no_parameter_defaults_for_update_commands` rule - update command params should not have default values. This is so that they behave as no-ops when not set. --- **severity high**
- [x] Add `update_commands_support_generic_update`  rule - all update commands should expose generic update arguments. --- **severity high**
- [x] Command command loaders must have an associated resource type --- **severity high**
- [x] expose wait command if a command in a group has --no-wait --- **severity medium**
- [ ] location should not be required in a command. One can always default to resource group's location. --- **severity medium**
- [ ] Delete commands of top level resources should prompt user for confirmation or accept --yes (not necessary if the resource is not a top level resource.). --- **severity medium**
- [ ] arguments that end in `-id` smust be guids / uuids and not resource ids. This involves guessing from help text, and so this should be a medium or even low severity as we might not even be sure when warning the user. --- **severity low**

Todo: add other rules to assist in command reviews and to maintain CLI command / param / help quality

such as:
- create / list commands should not have `--ids`. We have a check for list commands and its not possible to expose --ids on create commands. We might need to scrap this. --- **severity medium**. 
- When specifying parameter choices, they should use sdk enums [and get_enum_type). This might not be possible as is. it might be possible to detect this by adding a flag when registering arguments during command load, but that might not be worth it. --- **severity medium**

- Generally, an argument that accepts only one value should not be required, but default to the single value. An exception is in the event where it is possible / expected that this argument will take multiple values in the future, then it is fair not to default to a value. --- **severity low**
