### PR TITLE
[Document] Update windows virtual env activation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ The `azdev` tool is designed to aid new and experienced developers in contributi
 
     Windows CMD.exe:
     ```BatchFile
-    env\scripts\activate.bat
+    env\Scripts\activate.bat
     ```
 
     Windows Powershell:
     ```
-    env\scripts\activate.ps1
+    env\Scripts\activate.ps1
     ```
 
     OSX/Linux (bash):


### PR DESCRIPTION
On windows the path is usually ` env\Scripts\`  and not `env\scripts\` from my experience.