### PR TITLE
Fix bug that get_ext_repo_paths() unable to raise NoSectionError forever

### DIFF
--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -192,9 +192,9 @@ def update_extension_index(extensions):
     ext_repos = get_ext_repo_paths()
     index_path = next((x for x in find_files(ext_repos, 'index.json') if 'azure-cli-extensions' in x), None)
     if not index_path:
-        raise CLIError("Unable to find 'index.json' in your extension repos. Have "
-                       "you cloned 'azure-cli-extensions' and added it to you repo "
-                       "sources with `azdev extension repo add`?")
+        raise CLIError("Unable to find 'index.json' in your extension repos. "
+                       "Have you cloned 'azure-cli-extensions'?"
+                       "Then setup or add you repo source with 'azdev extension repo add'?")
 
     NAME_REGEX = r'.*/([^/]*)-\d+.\d+.\d+'
 

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -204,29 +204,29 @@ def update_extension_index(extensions):
             raise CLIError('usage error: only URL to a WHL file currently supported.')
 
         # TODO: extend to consider other options
-        ext_path = extension
+        ext_url = extension
 
         # Extract the extension name
         try:
-            extension_name = re.findall(NAME_REGEX, ext_path)[0]
+            extension_name = re.findall(NAME_REGEX, ext_url)[0]
             extension_name = extension_name.replace('_', '-')
         except IndexError:
-            raise CLIError('Unable to parse extension name from path [ {} ]'.format(ext_path))
+            raise CLIError('Unable to parse extension name from path [ {} ]'.format(ext_url))
 
         # TODO: Update this!
         extensions_dir = tempfile.mkdtemp()
         ext_dir = tempfile.mkdtemp(dir=extensions_dir)
         whl_cache_dir = tempfile.mkdtemp()
         whl_cache = {}
-        ext_file = get_whl_from_url(ext_path, extension_name, whl_cache_dir, whl_cache)
+        ext_file = get_whl_from_url(ext_url, extension_name, whl_cache_dir, whl_cache)
 
         with open(index_path, 'r') as infile:
             curr_index = json.loads(infile.read())
 
         entry = {
-            'downloadUrl': ext_path,
+            'downloadUrl': ext_url,
             'sha256Digest': _get_sha256sum(ext_file),
-            'filename': ext_path.split('/')[-1],
+            'filename': ext_url.split('/')[-1],
             'metadata': get_ext_metadata(ext_dir, ext_file, extension_name)
         }
 
@@ -238,7 +238,7 @@ def update_extension_index(extensions):
             curr_index['extensions'][extension_name].append(entry)
 
         # update index and write back to file
-        with open(os.path.join(index_path), 'w') as outfile:
+        with open(index_path, 'w') as outfile:
             outfile.write(json.dumps(curr_index, indent=4, sort_keys=True))
 
 

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -211,7 +211,7 @@ def update_extension_index(extensions):
             extension_name = re.findall(NAME_REGEX, ext_path)[0]
             extension_name = extension_name.replace('_', '-')
         except IndexError:
-            raise CLIError('unable to parse extension name')
+            raise CLIError('Unable to parse extension name from path [ {} ]'.format(ext_path))
 
         # TODO: Update this!
         extensions_dir = tempfile.mkdtemp()

--- a/azdev/operations/extensions/util.py
+++ b/azdev/operations/extensions/util.py
@@ -69,12 +69,15 @@ def get_whl_from_url(url, filename, tmp_dir, whl_cache=None):
         whl_cache = {}
     if url in whl_cache:
         return whl_cache[url]
+
     import requests
+
     r = requests.get(url, stream=True)
     try:
-        assert r.status_code == 200, "Request to {} failed with {}".format(url, r.status_code)
-    except AssertionError:
-        raise CLIError("unable to download (status code {}): {}".format(r.status_code, url))
+        r.raise_for_status()
+    except Exception:
+        raise CLIError("Unable to download (status code {}): {}".format(r.status_code, url))
+
     ext_file = os.path.join(tmp_dir, filename)
     with open(ext_file, 'wb') as f:
         for chunk in r.iter_content(chunk_size=1024):

--- a/azdev/operations/extensions/util.py
+++ b/azdev/operations/extensions/util.py
@@ -83,5 +83,7 @@ def get_whl_from_url(url, filename, tmp_dir, whl_cache=None):
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # ignore keep-alive new chunks
                 f.write(chunk)
+
     whl_cache[url] = ext_file
+
     return ext_file

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -102,7 +102,8 @@ def load_arguments(self, _):
             c.positional('repos', metavar='PATH', nargs='+', help='Space-separated list of paths to Git repositories.')
 
     with ArgumentsContext(self, 'extension update-index') as c:
-        c.positional('extensions', nargs='+', metavar='URL', help='Space-separated list of URLs to extension WHL files.')
+        c.positional('extensions', nargs='+', metavar='URLs',
+                     help='Space-separated list of URLs to extension WHL files.')
 
     with ArgumentsContext(self, 'cli create') as c:
         c.positional('mod_name', help='Name of the module to create.')

--- a/azdev/utilities/path.py
+++ b/azdev/utilities/path.py
@@ -75,7 +75,8 @@ def get_ext_repo_paths():
     try:
         return get_azdev_config().get('ext', 'repo_paths').split(',')
     except NoSectionError:
-        raise CLIError('Unable to retrieve extensions repo path from config. Please run `azdev setup`.')
+        raise CLIError('Unable to retrieve extensions repo path from config. '
+                       'Please run `azdev setup` with -r to specify path to your azure-cli-extensions repo.')
 
 
 def find_file(file_name):


### PR DESCRIPTION
- Update help and error message for 'extension update-index'
- Leverage requests API by replacing assertion for HTTP status code with requests.raise_for_status()
- Remove unnecessary tempfile used in storing temporary wheel file
- Fix bug that get_ext_repo_paths() unable to raise NoSectionError forever