### PR TITLE
azdev extension publish: Add one more argument storage account key

### DIFF
--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -270,7 +270,7 @@ def build_extensions(extensions, dist_dir='dist'):
     os.chdir(original_cwd)
 
 
-def publish_extensions(extensions, storage_subscription, storage_account, storage_container,
+def publish_extensions(extensions, storage_subscription, storage_account, storage_account_key, storage_container,
                        dist_dir='dist', update_index=False, yes=False):
 
     heading('Publish Extensions')
@@ -293,11 +293,10 @@ def publish_extensions(extensions, storage_subscription, storage_account, storag
         whl_file = os.path.split(whl_path)[-1]
         # check if extension already exists unless user opted not to
         if not yes:
-            command = 'az storage blob exists --subscription {} --account-name {} -c {} -n {}'.format(
-                storage_subscription, storage_account, storage_container, whl_file)
-            # Retrieve just the JSON result
-            result = cmd(command).result
-            exists = json.loads(result[result.index('{'):])['exists']
+            command = 'az storage blob exists --subscription {} --account-name {} --account-key {} -c {} -n {}'.format(
+                      storage_subscription, storage_account, storage_account_key, storage_container, whl_file)
+            exists = json.loads(cmd(command).result)['exists']
+
             if exists:
                 if not prompt_y_n(
                         "{} already exists. You may need to bump the extension version. Replace?".format(whl_file),

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -270,7 +270,7 @@ def build_extensions(extensions, dist_dir='dist'):
     os.chdir(original_cwd)
 
 
-def publish_extensions(extensions, storage_subscription, storage_account, storage_account_key, storage_container,
+def publish_extensions(extensions, storage_account, storage_account_key, storage_container,
                        dist_dir='dist', update_index=False, yes=False):
 
     heading('Publish Extensions')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -92,6 +92,8 @@ def load_arguments(self, _):
         c.argument('storage_account', help='Name of the storage account to publish to. Environment variable: AZDEV_DEFAULTS_STORAGE_ACCOUNT.', arg_group='Storage', configured_default='storage_account')
         c.argument('storage_container', help='Name of the storage container to publish to. Environment variable: AZDEV_DEFAULTS_STORAGE_CONTAINER.', arg_group='Storage', configured_default='storage_container')
         c.argument('storage_subscription', help='Subscription ID of the storage account. Environment variable: AZDEV_DEFAULTS_STORAGE_SUBSCRIPTION.', arg_group='Storage', configured_default='storage_subscription')
+        c.argument('storage_account_key', help='Key of the storage account to publish to. ', arg_group='Storage',
+                   configured_default='storage_account')
 
     for scope in ['extension add', 'extension remove', 'extension build', 'extension publish']:
         with ArgumentsContext(self, scope) as c:

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -91,7 +91,6 @@ def load_arguments(self, _):
     with ArgumentsContext(self, 'extension publish') as c:
         c.argument('storage_account', help='Name of the storage account to publish to. Environment variable: AZDEV_DEFAULTS_STORAGE_ACCOUNT.', arg_group='Storage', configured_default='storage_account')
         c.argument('storage_container', help='Name of the storage container to publish to. Environment variable: AZDEV_DEFAULTS_STORAGE_CONTAINER.', arg_group='Storage', configured_default='storage_container')
-        c.argument('storage_subscription', help='Subscription ID of the storage account. Environment variable: AZDEV_DEFAULTS_STORAGE_SUBSCRIPTION.', arg_group='Storage', configured_default='storage_subscription')
         c.argument('storage_account_key', help='Key of the storage account to publish to. ', arg_group='Storage',
                    configured_default='storage_account')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,7 @@ jobs:
         . env/bin/activate
 
         # install azdev from source code
-        python setup.py install
+        pip install -e .
 
         # azdev setup
         git clone --quiet https://github.com/Azure/azure-cli.git

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
         'requests',
         'sphinx==1.6.7',
         'tox',
-        'wheel==0.30.0'
+        'wheel==0.30.0',
+        'azure-storage-blob>=1.3.1,<2.0.0',
     ],
     extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2', 'futures'],


### PR DESCRIPTION
There are two changes here:
1. Use sdk in azure-storage-blob toimplement "azdev extension publish"
2. Add an additional argument --storage-account-key

Previous behavior is that we query key for users. 