### PR TITLE
[CI] hotfix install command bug of setuptools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,7 @@ jobs:
         . env/bin/activate
 
         # install azdev from source code
-        pip install -e
+        pip install -e .
 
         # azdev setup
         git clone --quiet https://github.com/Azure/azure-cli.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,7 +162,7 @@ jobs:
         . env/bin/activate
 
         # install azdev from source code
-        python setup.py install
+        pip install -e
 
         # azdev setup
         git clone --quiet https://github.com/Azure/azure-cli.git


### PR DESCRIPTION
As mentioned in https://github.com/Azure/azure-cli-dev-tools/pull/154#issuecomment-597516082,
`python setup.py install/develop` would install the `azure.common`, but if run `azdev setup -c ../azure-ci` after that, the `azure.common` would disappear.