### PR TITLE
[extension] Fix issue if --yes is not provided while publish extension

### DIFF
--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -291,12 +291,12 @@ def publish_extensions(extensions, storage_account, storage_account_key, storage
     subheading('Uploading WHLs')
     for whl_path in whl_files:
         whl_file = os.path.split(whl_path)[-1]
+        from azure.storage.blob import BlockBlobService
+        client = BlockBlobService(account_name=storage_account, account_key=storage_account_key)
+        exists = client.exists(container_name=storage_container, blob_name=whl_file)
+
         # check if extension already exists unless user opted not to
         if not yes:
-            from azure.storage.blob import BlockBlobService
-            client = BlockBlobService(account_name=storage_account, account_key=storage_account_key)
-            exists = client.exists(container_name=storage_container, blob_name=whl_file)
-
             if exists:
                 if not prompt_y_n(
                         "{} already exists. You may need to bump the extension version. Replace?".format(whl_file),

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -272,6 +272,7 @@ def build_extensions(extensions, dist_dir='dist'):
 
 def publish_extensions(extensions, storage_account, storage_account_key, storage_container,
                        dist_dir='dist', update_index=False, yes=False):
+    from azure.storage.blob import BlockBlobService
 
     heading('Publish Extensions')
 
@@ -291,7 +292,7 @@ def publish_extensions(extensions, storage_account, storage_account_key, storage
     subheading('Uploading WHLs')
     for whl_path in whl_files:
         whl_file = os.path.split(whl_path)[-1]
-        from azure.storage.blob import BlockBlobService
+
         client = BlockBlobService(account_name=storage_account, account_key=storage_account_key)
         exists = client.exists(container_name=storage_container, blob_name=whl_file)
 


### PR DESCRIPTION
When `if not yes` condition is not satisfied, the following error will occur:
```
local variable 'client' referenced before assignment
```