### PR TITLE
Remove knack version lock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'flake8',
         'gitpython',
         'jinja2',
-        'knack~=0.6.2',
+        'knack',
         'mock',
         'pytest~=4.4.0',
         'pytest-xdist',


### PR DESCRIPTION
The lock on knack version causes problem once Azure CLI starts using knack 0.7.0rc1 

https://github.com/microsoft/knack/pull/185
https://github.com/Azure/azure-cli/pull/12604

```
(env38) PS D:\cli> azdev setup -c azure-cli -r azure-cli-extensions
Traceback (most recent call last):
  File "D:\cli\env38\Scripts\azdev-script.py", line 6, in <module>
    from pkg_resources import load_entry_point
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 3099, in <module>
    def _initialize_master_working_set():
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 3082, in _call_aside
    f(*args, **kwargs)
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 3111, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 573, in _build_master
    ws.require(__requires__)
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 891, in require
    needed = self.resolve(parse_requirements(requirements))
  File "d:\cli\env38\lib\site-packages\pkg_resources\__init__.py", line 777, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'knack~=0.6.2' distribution was not found and is required by azdev
```

