### PR TITLE
Remove py2 wheel bdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
Same as https://github.com/Azure/azure-cli/pull/12683

Remove `universal=1` so that PyPI doesn't mark the package as Python 2 supported: 

https://pypi.org/project/azdev/#files

azdev-0.1.10-py2.py3-none-any.whl (80.3 kB) | Wheel | py2.py3
-- | -- | --
