### PR TITLE
Support install of git submodules.

### DIFF
--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -33,7 +33,8 @@ def _check_path(path, file_name):
 
 
 def _check_repo(path):
-    if not os.path.isdir(os.path.join(path, '.git')):
+    full_path = os.path.join(path, '.git')
+    if not (os.path.isdir(full_path) or os.path.isfile(full_path)):
         raise CLIError("'{}' is not a valid git repository.".format(path))
 
 


### PR DESCRIPTION
`azdev setup` command looks for git repositories in various cases (e.g.
install azure-cli from source). It is a valid use case that the source
repos are not standalone git repositories but they are checked out as git
submodules. In this case, the .git entry is not a directory but it
is a file with reference to the parent repository. For example:

$ cat .git
gitdir: ../../.git/modules/src/azure-cli

To support this use case, the setup.py:_check_repo() function has been
extended to check for file existence not only for directory existence.