### PR TITLE
Add --deps-from to azdev setup and use requirements file to resolve dependencies by default

### DIFF
--- a/azdev/help.py
+++ b/azdev/help.py
@@ -26,6 +26,9 @@ helps['setup'] = """
 
         - name: Install CLI in dev mode, along with the extensions repo. Auto-find the CLI repo and install the `alias` extension in dev mode.
           text: azdev setup -c -r azure-cli-extensions -e alias
+
+        - name: Install only the CLI in dev mode and resolve dependencies from setup.py.
+          text: azdev setup -c -d setup
 """
 
 

--- a/azdev/help.py
+++ b/azdev/help.py
@@ -28,7 +28,7 @@ helps['setup'] = """
           text: azdev setup -c -r azure-cli-extensions -e alias
 
         - name: Install only the CLI in dev mode and resolve dependencies from setup.py.
-          text: azdev setup -c -d setup
+          text: azdev setup -c -d setup.py
 """
 
 

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -121,6 +121,6 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None,
     exit_code = linter_manager.run(
         run_params=not rule_types or 'params' in rule_types,
         run_commands=not rule_types or 'commands' in rule_types,
-        run_command_groups=not rule_types or 'command_groups'in rule_types,
+        run_command_groups=not rule_types or 'command_groups' in rule_types,
         run_help_files_entries=not rule_types or 'help_entries' in rule_types)
     sys.exit(exit_code)

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -84,6 +84,7 @@ def _install_cli(cli_path, deps=None):
         "Installing `requirements.txt`..."
     )
     if deps == 'setup.py':
+        # Resolve dependencies from setup.py files.
         # command modules have dependency on azure-cli-core so install this first
         pip_cmd(
             "install -q -e {}/src/azure-cli-nspkg".format(cli_path),
@@ -105,7 +106,8 @@ def _install_cli(cli_path, deps=None):
             "Installing `azure-cli-testsdk`..."
         )
     else:
-        # command modules have dependency on azure-cli-core so install this first
+        # First install packages without dependencies,
+        # then resolve dependencies from requirements.*.txt file.
         pip_cmd(
             "install -e {}/src/azure-cli-nspkg --no-deps".format(cli_path),
             "Installing `azure-cli-nspkg`..."
@@ -119,7 +121,6 @@ def _install_cli(cli_path, deps=None):
             "Installing `azure-cli-core`..."
         )
 
-        # azure cli has dependencies on the above packages so install this one last
         pip_cmd("install -e {}/src/azure-cli --no-deps".format(cli_path), "Installing `azure-cli`...")
         pip_cmd(
             "install -e {}/src/azure-cli-testsdk --no-deps".format(cli_path),

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -83,7 +83,7 @@ def _install_cli(cli_path, deps=None):
         "install -q -r {}/requirements.txt".format(cli_path),
         "Installing `requirements.txt`..."
     )
-    if deps == 'setup':
+    if deps == 'setup.py':
         # command modules have dependency on azure-cli-core so install this first
         pip_cmd(
             "install -q -e {}/src/azure-cli-nspkg".format(cli_path),
@@ -127,8 +127,6 @@ def _install_cli(cli_path, deps=None):
         )
         import platform
         system = platform.system()
-        if system == 'Windows':
-            system = system.lower()
         req_file = 'requirements.py3.{}.txt'.format(system)
         pip_cmd("install -r {}/src/azure-cli/{}".format(cli_path, req_file),
                 "Installing `{}`...".format(req_file))

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -36,7 +36,7 @@ def load_arguments(self, _):
         c.argument('cli_path', options_list=['--cli', '-c'], nargs='?', const=Flag, help="Path to an existing Azure CLI repo. Omit value to search for the repo or use special value 'EDGE' to install the latest developer edge build.")
         c.argument('ext_repo_path', options_list=['--repo', '-r'], nargs='+', help='Space-separated list of paths to existing Azure CLI extensions repos.')
         c.argument('ext', options_list=['--ext', '-e'], nargs='+', help="Space-separated list of extensions to install initially. Use '*' to install all extensions.")
-        c.argument('deps', options_list=['--deps', '-d'], choices=['requirements', 'setup'], default='requirements', help="Choose the file to resolve dependencies.")
+        c.argument('deps', options_list=['--deps-from', '-d'], choices=['requirements.txt', 'setup.py'], default='requirements.txt', help="Choose the file to resolve dependencies.")
 
     with ArgumentsContext(self, 'test') as c:
         c.argument('discover', options_list='--discover', action='store_true', help='Build an index of test names so that you don\'t need to specify fully qualified test paths.')

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -36,6 +36,7 @@ def load_arguments(self, _):
         c.argument('cli_path', options_list=['--cli', '-c'], nargs='?', const=Flag, help="Path to an existing Azure CLI repo. Omit value to search for the repo or use special value 'EDGE' to install the latest developer edge build.")
         c.argument('ext_repo_path', options_list=['--repo', '-r'], nargs='+', help='Space-separated list of paths to existing Azure CLI extensions repos.')
         c.argument('ext', options_list=['--ext', '-e'], nargs='+', help="Space-separated list of extensions to install initially. Use '*' to install all extensions.")
+        c.argument('deps', options_list=['--deps', '-d'], choices=['requirements', 'setup'], default='requirements', help="Choose the file to resolve dependencies.")
 
     with ArgumentsContext(self, 'test') as c:
         c.argument('discover', options_list='--discover', action='store_true', help='Build an index of test names so that you don\'t need to specify fully qualified test paths.')


### PR DESCRIPTION
Development part to solve https://github.com/Azure/azure-cli/issues/9781. 

This PR adds `--deps-from` option to `azev setup`. By default, use the `requirements.*.txt` file to resolve dependencies for Azure CLI project. Specify `--deps-from setup.py` to use `setup.py` files to resolve dependencies, which is the previous behavior.