### PR TITLE
Downgrade parameter_should_not_end_in_resource_group's severity to Medium

### DIFF
--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -45,7 +45,7 @@ def bad_short_option(linter, command_name, parameter_name):
                         'convert to a long-option.'.format(' | '.join(bad_options)))
 
 
-@ParameterRule(LinterSeverity.HIGH)
+@ParameterRule(LinterSeverity.MEDIUM)
 def parameter_should_not_end_in_resource_group(linter, command_name, parameter_name):
     options_list = linter.get_parameter_options(command_name, parameter_name)
     bad_options = []


### PR DESCRIPTION
We may need to rethink about this rule. We already met two teams want to pass this rule. Except for `--resource-group-name`, there are some commands need extra resource group parameter.
https://github.com/Azure/azure-cli/pull/14027 destination_resource_group
https://github.com/Azure/azure-cli-extensions/pull/1709 service_runtime_network_resource_group