### PR TITLE
Pin isort and revert pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'tox',
         'wheel==0.30.0',
         'azure-storage-blob>=1.3.1,<2.0.0',
-        'isort=4.3.21'
+        'isort==4.3.21'
     ],
     extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2', 'futures'],

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,11 @@ setup(
         'tox',
         'wheel==0.30.0',
         'azure-storage-blob>=1.3.1,<2.0.0',
+        'isort=4.3.21'
     ],
     extras_require={
         ":python_version<'3.0'": ['pylint==1.9.2', 'futures'],
-        ":python_version>='3.0'": ['pylint==2.5.3']
+        ":python_version>='3.0'": ['pylint==2.3.0']
     },
     package_data={
         'azdev.config': ['*.*', 'cli_pylintrc', 'ext_pylintrc'],


### PR DESCRIPTION
Pin `isort` and revert `pylint` update (https://github.com/Azure/azure-cli-dev-tools/pull/224).

No matter whether we use the **`main` branch of `azdev`** or the **released version on PyPI**, `pylint` will crash with `AttributeError: module 'isort' has no attribute 'SortImports'`, but `azdev` can't detect that (another bug). In such case, `pylint` doesn't work at all, giving a false positive indicating the style check passed. 
