### PR TITLE
[Linter] Only violation of high severity would exit with 1

### DIFF
--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -138,7 +138,7 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None,
         command_loader, help_file_entries, modules=selected_mod_names, include_whl_extensions=include_whl_extensions)
 
     if not command_loader.command_table:
-        raise CLIError('No commands selected to check.')
+        logger.warning('No commands selected to check.')
 
     # Instantiate and run Linter
     linter_manager = LinterManager(command_loader=command_loader,

--- a/azdev/operations/linter/__init__.py
+++ b/azdev/operations/linter/__init__.py
@@ -80,7 +80,7 @@ def run_linter(modules=None, rule_types=None, rules=None, ci_exclusions=None,
     selected_modules = filter_by_git_diff(selected_modules, git_source, git_target, git_repo)
 
     if not any((selected_modules[x] for x in selected_modules)):
-        raise CLIError('No modules selected.')
+        logger.warning('No commands selected to check.')
 
     selected_mod_names = list(selected_modules['mod'].keys()) + list(selected_modules['core'].keys()) + \
         list(selected_modules['ext'].keys())

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -211,8 +211,9 @@ class LinterManager(object):
 
             self._rules[rule_type][rule_name] = rule_callable, get_linter, rule_severity
 
-    def mark_rule_failure(self):
-        self._exit_code = 1
+    def mark_rule_failure(self, rule_severity):
+        if rule_severity is LinterSeverity.HIGH:
+            self._exit_code = 1
 
     @property
     def exclusions(self):

--- a/azdev/operations/linter/rule_decorators.py
+++ b/azdev/operations/linter/rule_decorators.py
@@ -54,7 +54,7 @@ class ParameterRule(BaseRule):
                             try:
                                 func(linter, command_name, parameter_name)
                             except RuleError as ex:
-                                linter_manager.mark_rule_failure()
+                                linter_manager.mark_rule_failure(self.severity)
                                 yield (_create_violation_msg(ex, 'Parameter: {}, `{}`', command_name, parameter_name),
                                        (command_name, parameter_name),
                                        func.__name__)
@@ -75,7 +75,7 @@ def _get_decorator(func, rule_group, print_format, severity):
                     try:
                         func(linter, iter_entity)
                     except RuleError as ex:
-                        linter_manager.mark_rule_failure()
+                        linter_manager.mark_rule_failure(severity)
                         yield (_create_violation_msg(ex, print_format, iter_entity), iter_entity, func.__name__)
 
         linter_manager.add_rule(rule_group, func.__name__, wrapper, severity)


### PR DESCRIPTION
Two changes
- Only violation of high severity would exit with 1.
- No module selected would exit with 0 instead of CLIError.