### PR TITLE
[Linter] Param's length cannot exceed 22 and name should not use `_`

### DIFF
--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -48,6 +48,8 @@ class Linter(object):  # pylint: disable=too-many-public-methods
         self._parameters = {}
         self._help_file_entries = set(help_file_entries.keys())
         self._command_parser = command_loader.cli_ctx.invocation.parser
+        self.total_count = 0
+        self.fail_count = 0
 
         for command_name, command in self._command_loader.command_table.items():
             self._parameters[command_name] = set()

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -48,8 +48,6 @@ class Linter(object):  # pylint: disable=too-many-public-methods
         self._parameters = {}
         self._help_file_entries = set(help_file_entries.keys())
         self._command_parser = command_loader.cli_ctx.invocation.parser
-        self.total_count = 0
-        self.fail_count = 0
 
         for command_name, command in self._command_loader.command_table.items():
             self._parameters[command_name] = set()

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -151,8 +151,6 @@ def option_length_too_long(linter, command_name, parameter_name):
             return
         min_length = min(min_length, len(option))
     if min_length > length_threshold:
-        # linter.fail_count += 1
-        # print(linter.fail_count)
         raise RuleError("The lengths of all options {} are longer than {} ".format(options_list, length_threshold))
 
 

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -144,7 +144,7 @@ def id_params_only_for_guid(linter, command_name, parameter_name):
 @ParameterRule(LinterSeverity.HIGH)
 def option_length_too_long(linter, command_name, parameter_name):
     min_length = 2147483647
-    length_threshold = 22 # only 5% argument's length exceed this value.
+    length_threshold = 22  # only 5% argument's length exceed this value.
     options_list = linter.get_parameter_options(command_name, parameter_name) or []
     for option in options_list:
         if isinstance(option, Deprecated) or option.startswith('--__'):

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -143,14 +143,14 @@ def id_params_only_for_guid(linter, command_name, parameter_name):
 
 @ParameterRule(LinterSeverity.HIGH)
 def option_length_too_long(linter, command_name, parameter_name):
-    min_length = 2147483647
+    min_length = None
     length_threshold = 22  # only 5% argument's length exceed this value.
     options_list = linter.get_parameter_options(command_name, parameter_name) or []
     for option in options_list:
         if isinstance(option, Deprecated) or option.startswith('--__'):
             return
-        min_length = min(min_length, len(option))
-    if min_length > length_threshold:
+        min_length = min(min_length, len(option)) if min_length else len(option)
+    if min_length and min_length > length_threshold:
         raise RuleError("The lengths of all options {} are longer than {} ".format(options_list, length_threshold))
 
 

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -144,7 +144,7 @@ def id_params_only_for_guid(linter, command_name, parameter_name):
 @ParameterRule(LinterSeverity.HIGH)
 def option_length_too_long(linter, command_name, parameter_name):
     min_length = 2147483647
-    length_threshold = 22
+    length_threshold = 22 # only 5% argument's length exceed this value.
     options_list = linter.get_parameter_options(command_name, parameter_name) or []
     for option in options_list:
         if isinstance(option, Deprecated) or option.startswith('--__'):

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -151,7 +151,10 @@ def option_length_too_long(linter, command_name, parameter_name):
             return
         min_length = min(min_length, len(option)) if min_length else len(option)
     if min_length and min_length > length_threshold:
-        raise RuleError("The lengths of all options {} are longer than {} ".format(options_list, length_threshold))
+        raise RuleError("The lengths of all options {} are longer than threshold {}. "
+                        "Argument {} must have a short abbreviation.".format(options_list,
+                                                                             length_threshold,
+                                                                             parameter_name))
 
 
 @ParameterRule(LinterSeverity.HIGH)

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -139,3 +139,28 @@ def id_params_only_for_guid(linter, command_name, parameter_name):
         if param_help and _help_contains_queries(param_help, queries):
             raise RuleError("An option {} ends with '-id'. Arguments ending with '-id' "
                             "must be guids/uuids and not resource ids.".format(options_list))
+
+
+@ParameterRule(LinterSeverity.HIGH)
+def option_length_too_long(linter, command_name, parameter_name):
+    min_length = 2147483647
+    length_threshold = 22
+    options_list = linter.get_parameter_options(command_name, parameter_name) or []
+    for option in options_list:
+        if isinstance(option, Deprecated) or option.startswith('--__'):
+            return
+        min_length = min(min_length, len(option))
+    if min_length > length_threshold:
+        # linter.fail_count += 1
+        # print(linter.fail_count)
+        raise RuleError("The lengths of all options {} are longer than {} ".format(options_list, length_threshold))
+
+
+@ParameterRule(LinterSeverity.HIGH)
+def option_should_not_contain_under_score(linter, command_name, parameter_name):
+    options_list = linter.get_parameter_options(command_name, parameter_name) or []
+    for option in options_list:
+        if isinstance(option, Deprecated) or option.startswith('--__'):
+            return
+        if '_' in option:
+            raise RuleError("Argument's option {} contains '_' which should be '-' instead.".format(option))


### PR DESCRIPTION
- param's length cannot exceed 22
- param's name should not have `_`

![image](https://user-images.githubusercontent.com/49134743/89386069-273f8680-d733-11ea-9df9-9c96bee0d797.png)
