### PR TITLE
Refine ADO coverage report output

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+omit = */tests/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
 
         azdev --version
 
-        python -m pytest azdev/ --ignore=azdev/mod_templates --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        python -m pytest azdev/ --ignore=azdev/mod_templates --junitxml=junit/test-results.xml --cov=azdev/ --cov-report=xml --cov-report=html
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '**/test-*.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
 
         azdev --version
 
-        python -m pytest azdev/ --ignore=azdev/mod_templates --junitxml=junit/test-results.xml --cov=azdev/ --cov-report=xml --cov-report=html
+        python -m pytest azdev/ --ignore=azdev/mod_templates --junitxml=junit/test-results.xml --cov=azdev --cov-report=xml --cov-report=html
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '**/test-*.xml'


### PR DESCRIPTION
The current report contains analytics of azure-cli and azure-cli-extensions as their code source is placed under --cov=. 

- Remove it
- Ignore analytics on test code.