### PR TITLE
pytest greater than 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'jinja2',
         'knack',
         'mock',
-        'pytest>=4.4.0',
+        'pytest>=4.6.0',
         'pytest-xdist', # depends on pytest-forked
         'pyyaml',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'jinja2',
         'knack',
         'mock',
-        'pytest>=4.6.0',
+        'pytest>=5.0.0',
         'pytest-xdist', # depends on pytest-forked
         'pyyaml',
         'requests',


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli-dev-tools/issues/211.

pytest 5.0.0 is the minial version to make test pass on Windows