### PR TITLE
Support --mark; Fix a bug of invoking external comand

### DIFF
--- a/azdev/operations/testtool/__init__.py
+++ b/azdev/operations/testtool/__init__.py
@@ -32,7 +32,7 @@ logger = get_logger(__name__)
 # pylint: disable=too-many-statements
 def run_tests(tests, xml_path=None, discover=False, in_series=False,
               run_live=False, profile=None, last_failed=False, pytest_args=None,
-              no_exit_first=False,
+              no_exit_first=False, mark=None,
               git_source=None, git_target=None, git_repo=None,
               cli_ci=False):
 
@@ -112,7 +112,8 @@ def run_tests(tests, xml_path=None, discover=False, in_series=False,
         runner = get_test_runner(parallel=not in_series,
                                  log_path=xml_path,
                                  last_failed=last_failed,
-                                 no_exit_first=no_exit_first)
+                                 no_exit_first=no_exit_first,
+                                 mark=mark)
         exit_code = runner(test_paths=test_paths, pytest_args=pytest_args)
 
     sys.exit(0 if not exit_code else 1)

--- a/azdev/operations/testtool/__init__.py
+++ b/azdev/operations/testtool/__init__.py
@@ -29,7 +29,7 @@ from .incremental_strategy import CLIAzureDevOpsContext
 logger = get_logger(__name__)
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements,too-many-locals
 def run_tests(tests, xml_path=None, discover=False, in_series=False,
               run_live=False, profile=None, last_failed=False, pytest_args=None,
               no_exit_first=False, mark=None,

--- a/azdev/operations/testtool/pytest_runner.py
+++ b/azdev/operations/testtool/pytest_runner.py
@@ -11,7 +11,7 @@ from knack.log import get_logger
 from azdev.utilities import call
 
 
-def get_test_runner(parallel, log_path, last_failed, no_exit_first):
+def get_test_runner(parallel, log_path, last_failed, no_exit_first, mark):
     """Create a pytest execution method"""
     def _run(test_paths, pytest_args):
 
@@ -25,6 +25,9 @@ def get_test_runner(parallel, log_path, last_failed, no_exit_first):
         if no_exit_first:
             arguments.remove('-x')
 
+        if mark:
+            arguments.append('-m "{}"'.format(mark))
+
         arguments.extend(test_paths)
         if parallel:
             arguments += ['-n', 'auto']
@@ -34,6 +37,7 @@ def get_test_runner(parallel, log_path, last_failed, no_exit_first):
             arguments += pytest_args
         cmd = 'python -m pytest {}'.format(' '.join(arguments))
         logger.info('Running: %s', cmd)
-        return call(cmd)
+        # return call(cmd)
+        return os.system(cmd)
 
     return _run

--- a/azdev/operations/testtool/pytest_runner.py
+++ b/azdev/operations/testtool/pytest_runner.py
@@ -37,7 +37,7 @@ def get_test_runner(parallel, log_path, last_failed, no_exit_first, mark):
             arguments += pytest_args
         cmd = 'python -m pytest {}'.format(' '.join(arguments))
         logger.info('Running: %s', cmd)
-        # return call(cmd)
-        return os.system(cmd)
+        return call(cmd)
+        # return os.system(cmd)
 
     return _run

--- a/azdev/operations/testtool/pytest_runner.py
+++ b/azdev/operations/testtool/pytest_runner.py
@@ -38,6 +38,5 @@ def get_test_runner(parallel, log_path, last_failed, no_exit_first, mark):
         cmd = 'python -m pytest {}'.format(' '.join(arguments))
         logger.info('Running: %s', cmd)
         return call(cmd)
-        # return os.system(cmd)
 
     return _run

--- a/azdev/params.py
+++ b/azdev/params.py
@@ -53,6 +53,7 @@ def load_arguments(self, _):
         c.argument('pytest_args', nargs=argparse.REMAINDER, options_list=['--pytest-args', '-a'], help='Denotes the remaining args will be passed to pytest.')
         c.argument('last_failed', options_list='--lf', action='store_true', help='Re-run the last tests that failed.')
         c.argument('no_exit_first', options_list='--no-exitfirst', action='store_true', help='Do not exit on first error or failed test')
+        c.argument('mark', help='Select tests with this mark. You can add @pytest.mark.custom_mark to a test')
 
         # CI parameters
         c.argument('cli_ci',

--- a/azdev/utilities/command.py
+++ b/azdev/utilities/command.py
@@ -5,7 +5,6 @@
 # -----------------------------------------------------------------------------
 
 import os
-import shlex
 import subprocess
 import sys
 
@@ -22,12 +21,9 @@ def call(command, **kwargs):
     :param kwargs: Any kwargs supported by subprocess.Popen
     :returns: (int) process exit code.
     """
-    from azdev.utilities import IS_WINDOWS
     return subprocess.call(
         command,
-        # shlex.split(command),
         shell=True,
-        # shell=IS_WINDOWS,
         **kwargs)
 
 

--- a/azdev/utilities/command.py
+++ b/azdev/utilities/command.py
@@ -5,6 +5,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+import shlex
 import subprocess
 import sys
 
@@ -23,8 +24,10 @@ def call(command, **kwargs):
     """
     from azdev.utilities import IS_WINDOWS
     return subprocess.call(
-        command.split(),
-        shell=IS_WINDOWS,
+        command,
+        # shlex.split(command),
+        shell=True,
+        # shell=IS_WINDOWS,
         **kwargs)
 
 


### PR DESCRIPTION
Select tests with this mark. You can add @pytest.mark.custom_mark to a test

The old code has a bug. It does not support quotes. Quotes are necessary when the value contains space.

I have tested in both Windows and Linux.