### PR TITLE
Pin pytest version to 6.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'jinja2',
         'knack',
         'mock',
-        'pytest>=5.0.0',
+        'pytest==6.0.2',
         'pytest-xdist', # depends on pytest-forked
         'pyyaml',
         'requests',


### PR DESCRIPTION
Pytest 6.1.0 introduced breaking changes.
https://docs.pytest.org/en/stable/changelog.html#changelog
https://github.com/Azure/azure-cli-dev-tools/issues/261