### PR TITLE
Fixes #272 Using get_ext_repo_paths to get repo paths

### DIFF
--- a/azdev/operations/style.py
+++ b/azdev/operations/style.py
@@ -14,7 +14,7 @@ from knack.util import CLIError, CommandResultItem
 
 from azdev.utilities import (
     display, heading, subheading, py_cmd, get_path_table, EXTENSION_PREFIX,
-    get_azdev_config, get_azdev_config_dir, require_azure_cli, filter_by_git_diff)
+    get_azdev_config, get_azdev_config_dir, get_ext_repo_paths, require_azure_cli, filter_by_git_diff)
 
 
 logger = get_logger(__name__)
@@ -201,7 +201,7 @@ def _config_file_path(style_type="pylint"):
 
     ext_repo_path = filter(
         lambda x: "azure-cli-extension" in x,
-        get_azdev_config().get("ext", "repo_paths").split(),
+        get_ext_repo_paths(),
     )
     try:
         ext_repo_path = next(ext_repo_path)


### PR DESCRIPTION
Using the defined function to get the repo_paths from the config rather than doing it manually resolves #272 for me

Shout at me if I've got something wrong, I've very little idea what I'm doing