### PR TITLE
azdev setup: show error if pip command fails

### DIFF
--- a/azdev/help.py
+++ b/azdev/help.py
@@ -14,6 +14,7 @@ helps[''] = """
 
 helps['setup'] = """
     short-summary: Set up your environment for development of Azure CLI command modules and/or extensions.
+    long-summary: Use --verbose to show the commands that are run, --debug to show the command output.
     examples:
         - name: Fully interactive setup.
           text: azdev setup

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -83,6 +83,7 @@ def _install_cli(cli_path, deps=None):
         "install -r {}".format(os.path.join(cli_path, "requirements.txt")),
         "Installing `requirements.txt`..."
     )
+
     cli_src = os.path.join(cli_path, 'src')
     if deps == 'setup.py':
         # Resolve dependencies from setup.py files.
@@ -97,8 +98,10 @@ def _install_cli(cli_path, deps=None):
         )
 
         # azure cli has dependencies on the above packages so install this one last
-        pip_cmd("install -e {}".format(os.path.join(cli_src, 'azure-cli')),
-                "Installing `azure-cli`...")
+        pip_cmd(
+            "install -e {}".format(os.path.join(cli_src, 'azure-cli')),
+            "Installing `azure-cli`..."
+        )
 
         pip_cmd(
             "install -e {}".format(os.path.join(cli_src, 'azure-cli-testsdk')),
@@ -116,8 +119,10 @@ def _install_cli(cli_path, deps=None):
             "Installing `azure-cli-core`..."
         )
 
-        pip_cmd("install -e {} --no-deps".format(os.path.join(cli_src, 'azure-cli')),
-                "Installing `azure-cli`...")
+        pip_cmd(
+            "install -e {} --no-deps".format(os.path.join(cli_src, 'azure-cli')),
+            "Installing `azure-cli`..."
+        )
 
         # The dependencies of testsdk are not in requirements.txt as this package is not needed by the
         # azure-cli package for running commands.
@@ -129,8 +134,10 @@ def _install_cli(cli_path, deps=None):
         import platform
         system = platform.system()
         req_file = 'requirements.py3.{}.txt'.format(system)
-        pip_cmd("install -r {}".format(os.path.join(cli_src, 'azure-cli', req_file)),
-                "Installing `{}`...".format(req_file))
+        pip_cmd(
+            "install -r {}".format(os.path.join(cli_src, 'azure-cli', req_file)),
+            "Installing `{}`...".format(req_file)
+        )
 
 
 def _copy_config_files():
@@ -315,10 +322,9 @@ def setup(cli_path=None, ext_repo_path=None, ext=None, deps=None):
     # install packages
     subheading('Installing packages')
 
-    # upgrade to latest pip
-    pip_cmd('install --upgrade pip', 'Upgrading pip...')
-
     try:
+        # upgrade to latest pip
+        pip_cmd('install --upgrade pip', 'Upgrading pip...')
         _install_cli(cli_path, deps=deps)
         _install_extensions(ext_to_install)
     except CommandError as err:

--- a/azdev/utilities/__init__.py
+++ b/azdev/utilities/__init__.py
@@ -14,7 +14,8 @@ from .command import (
     call,
     cmd,
     py_cmd,
-    pip_cmd
+    pip_cmd,
+    CommandError
 )
 from .const import (
     COMMAND_MODULE_PREFIX,
@@ -67,6 +68,7 @@ __all__ = [
     'cmd',
     'py_cmd',
     'pip_cmd',
+    'CommandError',
     'test_cmd',
     'get_env_path',
     'get_azure_config_dir',


### PR DESCRIPTION
The current `azdev setup` silences any error that happens. This leads to difficulties in troubleshooting installation dependencies (https://github.com/Azure/azure-cli-dev-tools/pull/274, https://github.com/Azure/azure-cli/pull/16655, https://github.com/Azure/azure-cli/issues/16611).

- This PR lets `pip_cmd` raise `CommandError` by default if `pip` command fails. For other references of `pip_cmd`s, they assume that `pip_cmd` succeeds. Now in case of failure, bare exception `CommandError` is raised.
- `az setup` now supports `--verbose` to show the commands that are run, `--debug` to show the command output.

```
azdev setup -c --debug

=======================
| Azure CLI Dev Setup |
=======================

Azure CLI:
    D:\cli\azure-cli


 Installing packages
=====================

Upgrading pip...
INFO: Running: D:\cli\env39\Scripts\python -m pip install --upgrade pip
DEBUG: Requirement already satisfied: pip in d:\cli\env39\lib\site-packages (21.0)
Collecting pip
  Using cached pip-21.0-py3-none-any.whl (1.5 MB)
  Using cached pip-20.3.4-py2.py3-none-any.whl (1.5 MB)

Installing `requirements.txt`...
INFO: Running: D:\cli\env39\Scripts\python -m pip install -r D:\cli\azure-cli\requirements.txt
DEBUG: Requirement already satisfied: setuptools==52.0.0 in d:\cli\env39\lib\site-packages (from -r D:\cli\azure-cli\requirements.txt (line 2)) (52.0.0)
Requirement already satisfied: pip>=9.0.1 in d:\cli\env39\lib\site-packages (from -r D:\cli\azure-cli\requirements.txt (line 3)) (21.0)

...

Installing `requirements.py3.Windows.txt`...
INFO: Running: D:\cli\env39\Scripts\python -m pip install -r D:\cli\azure-cli\src\azure-cli\requirements.py3.Windows.txt
ERROR: Command `D:\cli\env39\Scripts\python -m pip install -r D:\cli\azure-cli\src\azure-cli\requirements.py3.Windows.txt` failed with exit code 1:
...
  _openssl.c
  build\temp.win-amd64-3.9\Release\_openssl.c(575): fatal error C1083: Cannot open include file: 'openssl/opensslv.h': No such file or directory
  error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.28.29333\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
  ...
```