### PR TITLE
Change package dependency

### DIFF
--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -272,7 +272,7 @@ def build_extensions(extensions, dist_dir='dist'):
 
 def publish_extensions(extensions, storage_account, storage_account_key, storage_container,
                        dist_dir='dist', update_index=False, yes=False):
-    from azure.storage.blob import BlockBlobService
+    from azure.multiapi.storage.v2018_11_09.blob import BlockBlobService
 
     heading('Publish Extensions')
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'sphinx==1.6.7',
         'tox',
         'wheel==0.30.0',
-        'azure-storage-blob>=1.3.1,<2.0.0',
+        'azure-multiapi-storage',
         'isort==4.3.21'
     ],
     extras_require={


### PR DESCRIPTION
In previous version, we fix azure-storage-blob < 2.0.0 because storage code is for track1 and with version >= 12.0.0, azure-storage-blob goes to track2 package, which is not compatible with current code. Here is to use azure-multiple-storage, which includes both track1 and track2 SDK to avoid the dependency for fixed azure-storage-blob.