### PR TITLE
fix _copy_vendored_sdk issue

### DIFF
--- a/azdev/operations/code_gen.py
+++ b/azdev/operations/code_gen.py
@@ -124,7 +124,10 @@ def _copy_vendored_sdk(src_path, dest_path):
     import shutil
 
     try:
-        client_location = find_files(src_path, '_version.py')[0]
+        version_files = find_files(src_path, 'version.py')
+        if not version_files:
+            version_files = find_files(src_path, '_version.py')
+        client_location = version_files[0]
     except IndexError:
         raise CLIError('Unable to find client files.')
 

--- a/azdev/operations/code_gen.py
+++ b/azdev/operations/code_gen.py
@@ -124,7 +124,7 @@ def _copy_vendored_sdk(src_path, dest_path):
     import shutil
 
     try:
-        client_location = find_files(src_path, 'version.py')[0]
+        client_location = find_files(src_path, '_version.py')[0]
     except IndexError:
         raise CLIError('Unable to find client files.')
 


### PR DESCRIPTION
SDK has renamed version file from `version.py` to `_version.py`, which blocked vendor_sdk copy.