### PR TITLE
Add Python 3.9 to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
     keywords='azure',
     python_requires='>=3.6',


### PR DESCRIPTION
Add Python 3.9 to classifiers so that it appears in PyPI https://pypi.org/project/azdev/