### PR TITLE
Drop `mock` library

### DIFF
--- a/azdev/operations/help/refdoc/common/directives.py
+++ b/azdev/operations/help/refdoc/common/directives.py
@@ -5,7 +5,7 @@
 import copy
 import argparse
 from os.path import expanduser
-from mock import patch
+from unittest.mock import patch
 
 from docutils import nodes
 from docutils.statemachine import ViewList

--- a/azdev/operations/linter/rules/help_rules.py
+++ b/azdev/operations/linter/rules/help_rules.py
@@ -7,7 +7,7 @@
 import shlex
 
 import re
-import mock
+from unittest import mock
 
 from knack.log import get_logger
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'gitpython',
         'jinja2',
         'knack',
-        'mock',
         'pylint==2.8.2',
         'pytest-xdist',  # depends on pytest-forked
         'pytest>=5.0.0',


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/18976

Per https://pypi.org/project/mock/:

> mock is now part of the Python standard library, available as `unittest.mock` in Python 3.3 onwards.

As Azure CLI requires Python >= 3.6, we can drop `mock`. 