### PR TITLE
{CI} Migrate pipeline to new organization azclitools

### DIFF
--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: 'Extract Metadata'
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: Bash@3
     displayName: 'Extract Version'
@@ -30,7 +30,7 @@ jobs:
   dependsOn: ExtractMetadata
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.8'
@@ -53,7 +53,7 @@ jobs:
   timeoutInMinutes: 10
 
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:
@@ -97,7 +97,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:
@@ -129,7 +129,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:
@@ -161,7 +161,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:
@@ -193,7 +193,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:
@@ -224,7 +224,7 @@ jobs:
   displayName: "Performance Check on Linux"
   dependsOn: BuildPythonWheel
   pool:
-    name: 'pool-ubuntu-1804'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python37:

--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -10,7 +10,7 @@ jobs:
   displayName: 'Extract Metadata'
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   steps:
   - task: Bash@3
     displayName: 'Extract Version'
@@ -30,7 +30,7 @@ jobs:
   dependsOn: ExtractMetadata
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.8'
@@ -53,7 +53,7 @@ jobs:
   timeoutInMinutes: 10
 
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:
@@ -99,7 +99,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:
@@ -133,7 +133,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:
@@ -167,7 +167,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:
@@ -201,7 +201,7 @@ jobs:
   dependsOn: BuildPythonWheel
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:
@@ -234,7 +234,7 @@ jobs:
   displayName: "Performance Check on Linux"
   dependsOn: BuildPythonWheel
   pool:
-    vmImage: 'ubuntu-18.04'
+    name: 'pool-ubuntu-1804'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -56,8 +56,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -102,8 +100,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -136,8 +132,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -170,8 +164,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -204,8 +196,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -237,8 +227,6 @@ jobs:
     name: 'pool-ubuntu-1804'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -276,8 +264,6 @@ jobs:
 #     vmImage: 'vs2017-win2016'
 #   strategy:
 #     matrix:
-#       Python36:
-#         python.version: '3.6'
 #       Python38:
 #         python.version: '3.8'
 #   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
 - job: Tox
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   strategy:
     matrix:
       Python36:
@@ -44,7 +44,7 @@ jobs:
   displayName: 'Extract Metadata'
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: Bash@3
     displayName: 'Extract Version'
@@ -64,7 +64,7 @@ jobs:
   dependsOn: ExtractMetadata
   condition: succeeded()
   pool:
-    vmImage: 'ubuntu-20.04'
+    name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.9'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,9 +12,6 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-        tox_env: 'py36'
       Python37:
         python.version: '3.7'
         tox_env: 'py37'


### PR DESCRIPTION
Migrate pipeline to azclitools org.

[Build pipeline Azure.azdev](https://dev.azure.com/azclitools/public/_build?definitionId=60)
[Build pipeline Azure.azdev-cli](https://dev.azure.com/azclitools/public/_build?definitionId=61)
[Release pipeline](https://dev.azure.com/azclitools/release/_release?_a=releases&view=all&definitionId=6)

Drop python3.6 becasue azure-cli-core requires python >=3.7.0:
![image](https://user-images.githubusercontent.com/18628534/190581402-e7cfb42b-7af3-40f8-a108-bfb8146ddb70.png)
