### PR TITLE
{CI} pytest: `--boxed` argument is deprecated, use `--forked` instead

### DIFF
--- a/azdev/operations/testtool/pytest_runner.py
+++ b/azdev/operations/testtool/pytest_runner.py
@@ -18,7 +18,7 @@ def get_test_runner(parallel, log_path, last_failed, no_exit_first, mark):
         logger = get_logger(__name__)
 
         if os.name == 'posix':
-            arguments = ['-x', '-v', '--boxed', '-p no:warnings', '--log-level=WARN', '--junit-xml', log_path]
+            arguments = ['-x', '-v', '--forked', '-p no:warnings', '--log-level=WARN', '--junit-xml', log_path]
         else:
             arguments = ['-x', '-v', '-p no:warnings', '--log-level=WARN', '--junit-xml', log_path]
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'knack',
         'pylint==2.11.1',
         'pytest-xdist',  # depends on pytest-forked
+        'pytest-forked',
         'pytest>=5.0.0',
         'pyyaml',
         'requests',


### PR DESCRIPTION
The latest pytest-xdist 3.0.2 (2022-10-25) has [removed](https://pytest-xdist.readthedocs.io/en/latest/changelog.html#removals) `--boxed` argument.
But we still need this functionality, install [pytest-forked](https://pypi.org/project/pytest-forked) separately and use `--forked` instead.
Error log:
```
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --boxed
  inifile: None
  rootdir: /mnt/vss/_work/1/s/src/azure-cli-core
```
Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/197946163-206d4c2b-3aa9-480f-a61f-b2113a858c05.png)
![image](https://user-images.githubusercontent.com/18628534/197946207-c57f8e73-7463-484e-8a8b-dcbd525b8d28.png)
