### PR TITLE
fix: Disable flake8 w503

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ ignore =
     F401,
     F811,
     C901,
+    W503,
     W504
 
 exclude = 

--- a/azdev/config/cli.flake8
+++ b/azdev/config/cli.flake8
@@ -7,6 +7,7 @@ ignore =
     F401,  # imported but unused, too many violations, to be removed in the future
     F811,  # redefinition of unused, to be removed in the future
     C901   # code flow is too complex, too many violations, to be removed in the future
+    W503   # line break before binary operator
     W504   # line break after binary operator effect on readability is subjective
 exclude = 
     azure_cli_bdist_wheel.py

--- a/azdev/config/ext.flake8
+++ b/azdev/config/ext.flake8
@@ -7,6 +7,7 @@ ignore =
     F401,  # imported but unused, too many violations, to be removed in the future
     F811,  # redefinition of unused, to be removed in the future
     C901   # code flow is too complex, too many violations, to be removed in the future
+    W503   # line break before binary operator
     W504   # line break after binary operator effect on readability is subjective
 exclude = 
     */vendored_sdks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel"]
-
-[tool.black]
-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel"]
+
+[tool.black]
+line-length = 120


### PR DESCRIPTION
When using [black](https://pypi.org/project/black/) to autoformat an extension one flake8 rule fails on a rule which does not follow pep8. W503 is disabled by default, but because the .flake8 files are using "ignore" instead of "extend-ignore", W503 is enabled in our ruleset. The maintainer of flake8 explained [here](https://stackoverflow.com/a/67945402/1341806) I recommend that we disable this rule, so that people may follow pep8 while also being able to use `black` to autoformat their code.

Line break occurred before a binary operator [(W503)](https://www.flake8rules.com/rules/W503.html)

`This rule goes against the PEP 8 recommended style, which was changed on April 16th, 2016 in [this commit](https://github.com/python/peps/commit/c59c4376ad233a62ca4b3a6060c81368bd21e85b). The tool [will soon be updated](https://github.com/PyCQA/pycodestyle/pull/502) to recommend the opposite: line breaks should occur before the binary operator because it keeps all operators aligned.`

## Code Before Autoformat
```python
    def is_equal(self, other):
        return (
            self.__class__ == other.__class__ and
            self.type == other.type and
            self.name == other.name and
            self.email == other.email and
            self.phone == other.phone and
            self.uri == other.uri
        )
```

## Code After Autoformat
```python
    def is_equal(self, other):
        return (
            self.__class__ == other.__class__
            and self.type == other.type
            and self.name == other.name
            and self.email == other.email
            and self.phone == other.phone
            and self.uri == other.uri
        )
```

## Flake8 Output
```
Running flake8 on extensions...
/workspaces/partnercenter-cli-extension/partnercenter/azext_partnercenter/models/listing_contact.py:29:13: W503 line break before binary operator
/workspaces/partnercenter-cli-extension/partnercenter/azext_partnercenter/models/listing_contact.py:30:13: W503 line break before binary operator
/workspaces/partnercenter-cli-extension/partnercenter/azext_partnercenter/models/listing_contact.py:31:13: W503 line break before binary operator
/workspaces/partnercenter-cli-extension/partnercenter/azext_partnercenter/models/listing_contact.py:32:13: W503 line break before binary operator
/workspaces/partnercenter-cli-extension/partnercenter/azext_partnercenter/models/listing_contact.py:33:13: W503 line break before binary operator
5     W503 line break before binary operator
```

