### PR TITLE
load parameter from module loader

### DIFF
--- a/azdev/operations/command_change/__init__.py
+++ b/azdev/operations/command_change/__init__.py
@@ -95,6 +95,8 @@ def export_command_meta(modules=None, git_source=None, git_target=None, git_repo
             "is_preview": command.command_kwargs.get("is_preview", False)
         }
         module_loader = command_loader.cmd_to_loader_map[command_name]
+        for loader in module_loader:
+            loader.skip_applicability = True
         codegen_info = _command_codegen_info(command_name, command, module_loader)
         if codegen_info:
             command_info['codegen_version'] = codegen_info['version']


### PR DESCRIPTION
`skip_applicability` triggers the `ArgumentsContext` to parse and merge arguments' kwargs from various sources. If not settled, arguments' kwargs is based on the cmd's customization function (don't know what's this action's purpose but its impact is what it is).

In this issue, because parameter `show_auth_for_sdk` or `show_auth_in_json` is parsed from its customization function, without its `ArgumentsContext` configured `options_list`, so they are marked as different parameter. 

After set `skip_applicability=True`, `options_list` is used to binding these two parameters and current `azdev command-change meta-diff` tool can comprehend that `[--sdk-auth]` is included in `[--sdk-auth, --json-auth]` and can be reviewed as the same parameter for users (see https://github.com/AllyW/azure-cli-dev-tools/blob/4dd3939b84ab0b7f744837d1e6bab3776731cbbb/azdev/operations/command_change/custom.py#L176), therefore this issue is fixed.