### PR TITLE
Disable sending cli telemetry for azdev test

### DIFF
--- a/azdev/operations/testtool/profile_context.py
+++ b/azdev/operations/testtool/profile_context.py
@@ -4,6 +4,7 @@
 # license information.
 # -----------------------------------------------------------------------------
 
+import os
 import traceback
 
 from knack.log import get_logger
@@ -14,6 +15,7 @@ from azdev.utilities import display
 
 
 logger = get_logger(__name__)
+os.environ['AZURE_CORE_COLLECT_TELEMETRY'] = 'False'
 
 
 class ProfileContext:


### PR DESCRIPTION
`azdev test` may execute cli commands `az cloud show` or `az cloud set` for choosing profiles.
Those cli commands which are executed within scenario tests won't send cli telemetry, but the `az cloud show/set` executed within `azdev` will create dozens of records in cli telemetry.

This PR aims to disable sending cli telemetry while calling `az cloud set/show` within `azdev test`