### PR TITLE
Fix two issues

### DIFF
--- a/azdev/operations/regex.py
+++ b/azdev/operations/regex.py
@@ -89,11 +89,11 @@ def search_argument_context(row_num, lines):
     while row_num > 0:
         row_num -= 1
         # Match `with self.argument_context(['"]['"]) as c:`
-        sub_pattern0 = r'with self.argument_context\(\'(.*?)\'[\),]'
+        sub_pattern0 = r'with self.argument_context\([\'\"](.*?)[\'\"][\),]'
         # Match `with self.argument_context(scope) as c:`
         sub_pattern1 = r'with self.argument_context\(scope[\),]'
         # Match `with self.argument_context(['"]{} stop['"].format(scope)) as c:',
-        sub_pattern2 = r'with self.argument_context\(\'(.*)\'.format\(scope\)\)'
+        sub_pattern2 = r'with self.argument_context\([\'\"](.*)[\'\"].format\(scope\)\)'
         # There are many matching patterns, but their proportion is very small. Ignore these commands.
         ref0 = re.findall(sub_pattern0, lines[row_num])
         ref1 = re.findall(sub_pattern1, lines[row_num])

--- a/azdev/operations/regex.py
+++ b/azdev/operations/regex.py
@@ -88,16 +88,17 @@ def search_argument_context(row_num, lines):
     cmds = []
     while row_num > 0:
         row_num -= 1
-        # Match `with self.argument_context('') as c:`
+        # Match `with self.argument_context(['"]['"]) as c:`
         sub_pattern0 = r'with self.argument_context\(\'(.*?)\'[\),]'
         # Match `with self.argument_context(scope) as c:`
         sub_pattern1 = r'with self.argument_context\(scope[\),]'
-        # Match `with self.argument_context(\'{} stop\'.format(scope)) as c:',
+        # Match `with self.argument_context(['"]{} stop['"].format(scope)) as c:',
         sub_pattern2 = r'with self.argument_context\(\'(.*)\'.format\(scope\)\)'
+        # There are many matching patterns, but their proportion is very small. Ignore these commands.
         ref0 = re.findall(sub_pattern0, lines[row_num])
         ref1 = re.findall(sub_pattern1, lines[row_num])
         ref2 = re.findall(sub_pattern2, lines[row_num])
-        # Match `with self.argument_context('') as c:`
+        # Match `with self.argument_context(['"]['"]) as c:`
         if ref0:
             cmds = ref0
             break
@@ -107,7 +108,7 @@ def search_argument_context(row_num, lines):
             cmds = json.loads(
                 re.findall(sub_pattern, lines[row_num - 1])[0].replace('\'', '"'))
             break
-        # Match `with self.argument_context(\'{} stop\'.format(scope)) as c:',
+        # Match `with self.argument_context(['"]{} stop['"].format(scope)) as c:',
         if ref2:
             sub_pattern = r'for scope in (.*):'
             format_strings = json.loads(

--- a/azdev/operations/style.py
+++ b/azdev/operations/style.py
@@ -192,16 +192,15 @@ def _run_pep8(modules):
 
 
 def _config_file_path(style_type="pylint"):
-    cli_repo_path = get_azdev_config().get("cli", "repo_path")
-
-    ext_repo_path = filter(
-        lambda x: "azure-cli-extension" in x,
-        get_azdev_config().get("ext", "repo_paths").split(),
-    )
+    from configparser import NoSectionError
     try:
-        ext_repo_path = next(ext_repo_path)
-    except StopIteration:
-        ext_repo_path = []
+        cli_repo_path = get_azdev_config().get("cli", "repo_path")
+    except NoSectionError:
+        cli_repo_path = None
+    try:
+        ext_repo_path = get_azdev_config().get("ext", "repo_paths").split(',')[0]
+    except NoSectionError:
+        ext_repo_path = None
 
     if style_type not in ["pylint", "flake8"]:
         raise ValueError("style_tyle value allows only: pylint, flake8.")


### PR DESCRIPTION
1. when I capture cmd, I only consider single quotes, add support for double quotes.
![image](https://github.com/Azure/azure-cli-dev-tools/assets/18628534/a640379e-2ad7-4ee5-b0f0-9a3f971ad02f)
![image](https://github.com/Azure/azure-cli-dev-tools/assets/18628534/21eb49ca-c72b-48f4-a389-581b49ad7685)
2. Fix azdev style get_ext_repo_path issue
`lambda x: "azure-cli-extension" in x,` assume that extension repo path must include auzre-cli-extension,
but actually in CI environment, the extension repo path is `/mnt/vss/_work/1/s`
this will cause azdev can not get extension repo path, so it will use the pylint and flake8 configuration file in azdev repo.
these configuration files is not consistent with main repo config file and extension repo config file.
finally the azdev style check result in CI environment is not consistent with in local machine. 
I am suprised that this issue has existed in our repo for more than three years.
![image](https://github.com/Azure/azure-cli-dev-tools/assets/18628534/adff5b07-bf7e-4ea6-a261-bbbf44ff6c2f)
![image](https://github.com/Azure/azure-cli-dev-tools/assets/18628534/e1d1e056-6d26-4dcf-ba3d-9b939ed75e1f)
![image](https://github.com/Azure/azure-cli-dev-tools/assets/18628534/ad5df0c6-bb88-439e-94a4-658c44c929e7)


