### PR TITLE
{CI} Disable too-many-positional-arguments R0917

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,7 @@ disable=
     raise-missing-from,
     too-few-public-methods,
     too-many-arguments,
+    too-many-positional-arguments,
     consider-using-f-string,
     unspecified-encoding,
     # These rules were added in Pylint >= 2.12, disable them to avoid making retroactive change


### PR DESCRIPTION
Disable too-many-positional-arguments ([R0917](https://pylint.readthedocs.io/en/latest/user_guide/checkers/features.html)):
Too many positional arguments (%s/%s) Used when a function has too many positional arguments.
![image](https://github.com/user-attachments/assets/273ca007-d2db-4549-96e0-1bc36910934e)
https://github.com/Azure/azure-cli/pull/29952#issuecomment-2367160707
It's added in Pylint 3.3 on 2024-09-20
> Added too-many-positional-arguments to allow distinguishing the configuration for too many total arguments (with keyword-only params specified after *) from the configuration for too many positional-or-keyword or positional-only arguments.
Ref: https://pylint.readthedocs.io/en/latest/whatsnew/3/3.3/index.html