### PR TITLE
add html tag and broken link detection in linter

### DIFF
--- a/azdev/operations/constant.py
+++ b/azdev/operations/constant.py
@@ -82,7 +82,7 @@ EXCLUDE_MODULES = [
 
 # refer to doc: https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies/allowed-html?branch=main
 ALLOWED_HTML_TAG = [
-    "a", "address", "article", "b", "blockquote", "br", "button",
+    "a", "address", "article", "b", "blockquote", "br", "button", "br /",
     "caption", "center", "cite", "code", "col", "colgroup",
     "dd", "del", "details", "div", "dl", "dt", "em", "figcaption", "figure", "form",
     "h1", "h2", "h3", "h4", "head", "hr",

--- a/azdev/operations/constant.py
+++ b/azdev/operations/constant.py
@@ -79,6 +79,23 @@ EXCLUDE_MODULES = [
     'util'
 ]
 
+# refer to doc: https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies/allowed-html?branch=main
+ALLOWED_HTML_TAG = [
+    "a", "address", "article", "b", "blockquote", "br", "button",
+    "caption", "center", "cite", "code", "col", "colgroup",
+    "dd", "del", "details", "div", "dl", "dt", "em", "figcaption", "figure", "form",
+    "h1", "h2", "h3", "h4", "head", "hr",
+    "i", "iframe", "image", "img", "input", "ins", "kbd",
+    "label", "li", "nav", "nobr", "ol", "p", "pre", "rgn",
+    "s", "section", "source", "span", "strike", "strong", "sub", "summary", "sup",
+    "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+    "u", "ul", "wbr"
+]
+
+DISALLOWED_HTML_TAG_RULE_LINK = "https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main"
+
+BROKEN_LINK_RULE_LINK = "https://review.learn.microsoft.com/en-us/help/platform/validation-ref/other-site-link-broken?branch=main"
+
 GLOBAL_EXCLUDE_COMMANDS = ['wait']
 
 EXCLUDE_COMMANDS = {

--- a/azdev/operations/constant.py
+++ b/azdev/operations/constant.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -----------------------------------------------------------------------------
+# pylint: disable=line-too-long
 
 ENCODING = 'utf-8'
 

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -379,11 +379,11 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
         for change in diff_patches:
             patch = change.diff.decode("utf-8")
             added_lines = [line for line in patch.splitlines() if line.startswith('+') and not line.startswith('+++')]
-            self.diffed_lines += set(added_lines)
+            self.diffed_lines |= set(added_lines)
             if added_lines:
-                print(f"Changes in file {change.a_path}:")
+                _logger.info(f"Changes in file {change.a_path}:")
                 for line in added_lines:
-                    print(line)
+                    _logger.info(line)
 
 
 # pylint: disable=too-many-instance-attributes

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -159,10 +159,6 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
 
         parameter_helps = command_help.parameters
         param_help = next((param for param in parameter_helps if share_element(options, param.name.split())), None)
-        # workaround for --ids which is not does not generate doc help (BUG)
-        if not param_help:
-            command_args = self._command_loader.command_table.get(command_name).arguments
-            return command_args.get(parameter_name).type.settings.get('help')
         return param_help
 
     def command_expired(self, command_name):

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -381,7 +381,7 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
             added_lines = [line for line in patch.splitlines() if line.startswith('+') and not line.startswith('+++')]
             self.diffed_lines |= set(added_lines)
             if added_lines:
-                _logger.info(f"Changes in file {change.a_path}:")
+                _logger.info("Changes in file '%s':", change.a_path)
                 for line in added_lines:
                     _logger.info(line)
 

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -66,7 +66,6 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
         self.diffed_lines = set()
         self._get_diffed_patches()
 
-
     @property
     def commands(self):
         return self._command_loader.command_table.keys()

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -53,7 +53,7 @@ def disallowed_html_tag_from_command_group(linter, command_group_name):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
-                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
     if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -45,7 +45,7 @@ def require_wait_command_if_no_wait(linter, command_group_name):
             raise RuleError("Group does not have a 'wait' command, yet '{}' exposes '--no-wait'".format(cmd))
 
 
-@CommandGroupRule(LinterSeverity.HIGH)
+@CommandGroupRule(LinterSeverity.MEDIUM)
 def disallowed_html_tag_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
@@ -64,7 +64,7 @@ def disallowed_html_tag_from_command_group(linter, command_group_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandGroupRule(LinterSeverity.HIGH)
+@CommandGroupRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -69,11 +69,9 @@ def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
-                                                                           linter.diffed_lines)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
-                                                                          linter.diffed_lines)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -49,12 +49,14 @@ def disallowed_html_tag_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary,
+                                                                             linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
-    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary,
+                                                                            linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
@@ -66,9 +68,11 @@ def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -6,6 +6,8 @@
 
 from ..rule_decorators import CommandGroupRule
 from ..linter import RuleError, LinterSeverity
+from ..util import has_illegal_html_tag, has_broken_site_links
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
 
 
 @CommandGroupRule(LinterSeverity.HIGH)
@@ -40,3 +42,33 @@ def require_wait_command_if_no_wait(linter, command_group_name):
     for cmd in group_command_names:
         if linter.get_command_metadata(cmd).supports_no_wait:
             raise RuleError("Group does not have a 'wait' command, yet '{}' exposes '--no-wait'".format(cmd))
+
+
+@CommandGroupRule(LinterSeverity.HIGH)
+def disallowed_html_tag_from_command_group(linter, command_group_name):
+    if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_group_name)
+    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
+        raise RuleError("Group '{}' has disallowed html tags in short summary. "
+                        "If tag is a placeholder, please wrap it with backtick."
+                        "For more info please refer to: {}".format(command_group_name, DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
+        raise RuleError("Group '{}' has disallowed html tags in long summary. "
+                        "If tag is a placeholder, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_group_name, DISALLOWED_HTML_TAG_RULE_LINK))
+
+
+@CommandGroupRule(LinterSeverity.HIGH)
+def broken_site_link_from_command_group(linter, command_group_name):
+    if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_group_name)
+    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
+        raise RuleError("Group '{}' has broken links in short summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_group_name, BROKEN_LINK_RULE_LINK))
+    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
+        raise RuleError("Group '{}' has broken links in long summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_group_name, BROKEN_LINK_RULE_LINK))

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -61,7 +61,7 @@ def disallowed_html_tag_from_command_group(linter, command_group_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandGroupRule(LinterSeverity.MEDIUM)
+@CommandGroupRule(LinterSeverity.HIGH)
 def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -7,7 +7,7 @@
 from ..rule_decorators import CommandGroupRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 
 
 @CommandGroupRule(LinterSeverity.HIGH)
@@ -49,26 +49,26 @@ def disallowed_html_tag_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
-        raise RuleError("Group '{}' has disallowed html tags in short summary. "
-                        "If tag is a placeholder, please wrap it with backtick."
-                        "For more info please refer to: {}".format(command_group_name, DISALLOWED_HTML_TAG_RULE_LINK))
-    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
-        raise RuleError("Group '{}' has disallowed html tags in long summary. "
-                        "If tag is a placeholder, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_group_name, DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+        raise RuleError("Disallowed html tags {} in short summary. "
+                        "If the content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+        raise RuleError("Disallowed html tags {} in long summary. "
+                        "If content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandGroupRule(LinterSeverity.HIGH)
+@CommandGroupRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
-        raise RuleError("Group '{}' has broken links in short summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_group_name, BROKEN_LINK_RULE_LINK))
-    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
-        raise RuleError("Group '{}' has broken links in long summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_group_name, BROKEN_LINK_RULE_LINK))
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+        raise RuleError("Broken links {} in short summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+        raise RuleError("Broken links {} in long summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -----------------------------------------------------------------------------
+# pylint: disable=duplicate-code
 
 from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import CommandGroupRule

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -4,10 +4,10 @@
 # license information.
 # -----------------------------------------------------------------------------
 
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import CommandGroupRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 
 
 @CommandGroupRule(LinterSeverity.HIGH)

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -38,6 +38,7 @@ def group_delete_commands_should_confirm(linter, command_name):
             raise RuleError("If this command deletes a collection, or group of resources. "
                             "Please make sure to ask for confirmation.")
 
+
 @CommandRule(LinterSeverity.HIGH)
 def disallowed_html_tag_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
@@ -47,7 +48,7 @@ def disallowed_html_tag_from_command(linter, command_name):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
-                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
     if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -56,7 +56,7 @@ def disallowed_html_tag_from_command(linter, command_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandRule(LinterSeverity.MEDIUM)
+@CommandRule(LinterSeverity.HIGH)
 def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -7,7 +7,7 @@
 from ..rule_decorators import CommandRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 
 @CommandRule(LinterSeverity.HIGH)
 def missing_command_help(linter, command_name):
@@ -42,26 +42,26 @@ def disallowed_html_tag_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
-        raise RuleError("Command '{}' has disallowed html tags in short summary. "
-                        "If tag is a placeholder, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, DISALLOWED_HTML_TAG_RULE_LINK))
-    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
-        raise RuleError("Command '{}' has disallowed html tags in long summary. "
-                        "If tag is a placeholder, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+        raise RuleError("Disallowed html tags {} in short summary. "
+                        "If the content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+        raise RuleError("Disallowed html tags {} in long summary. "
+                        "If content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandRule(LinterSeverity.HIGH)
+@CommandRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
-        raise RuleError("Command '{}' has broken links in short summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, BROKEN_LINK_RULE_LINK))
-    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
-        raise RuleError("Command '{}' has broken links in long summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, BROKEN_LINK_RULE_LINK))
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+        raise RuleError("Broken links {} in short summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+        raise RuleError("Broken links {} in long summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -64,7 +64,7 @@ def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summar)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
     if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -44,12 +44,14 @@ def disallowed_html_tag_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary,
+                                                                             linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
-    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary,
+                                                                            linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
@@ -61,9 +63,11 @@ def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -----------------------------------------------------------------------------
+# pylint: disable=duplicate-code
 
 from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import CommandRule

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -64,11 +64,9 @@ def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
-                                                                           linter.diffed_lines)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summar)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
-                                                                          linter.diffed_lines)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -40,7 +40,7 @@ def group_delete_commands_should_confirm(linter, command_name):
                             "Please make sure to ask for confirmation.")
 
 
-@CommandRule(LinterSeverity.HIGH)
+@CommandRule(LinterSeverity.MEDIUM)
 def disallowed_html_tag_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
@@ -59,7 +59,7 @@ def disallowed_html_tag_from_command(linter, command_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@CommandRule(LinterSeverity.HIGH)
+@CommandRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -6,7 +6,8 @@
 
 from ..rule_decorators import CommandRule
 from ..linter import RuleError, LinterSeverity
-
+from ..util import has_illegal_html_tag, has_broken_site_links
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
 
 @CommandRule(LinterSeverity.HIGH)
 def missing_command_help(linter, command_name):
@@ -35,3 +36,32 @@ def group_delete_commands_should_confirm(linter, command_name):
         if 'yes' not in linter.get_command_parameters(command_name):
             raise RuleError("If this command deletes a collection, or group of resources. "
                             "Please make sure to ask for confirmation.")
+
+@CommandRule(LinterSeverity.HIGH)
+def disallowed_html_tag_from_command(linter, command_name):
+    if command_name == '' or not linter.get_loaded_help_entry(command_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_name)
+    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
+        raise RuleError("Command '{}' has disallowed html tags in short summary. "
+                        "If tag is a placeholder, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
+        raise RuleError("Command '{}' has disallowed html tags in long summary. "
+                        "If tag is a placeholder, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, DISALLOWED_HTML_TAG_RULE_LINK))
+
+
+@CommandRule(LinterSeverity.HIGH)
+def broken_site_link_from_command(linter, command_name):
+    if command_name == '' or not linter.get_loaded_help_entry(command_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_name)
+    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
+        raise RuleError("Command '{}' has broken links in short summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, BROKEN_LINK_RULE_LINK))
+    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
+        raise RuleError("Command '{}' has broken links in long summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, BROKEN_LINK_RULE_LINK))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -4,10 +4,11 @@
 # license information.
 # -----------------------------------------------------------------------------
 
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import CommandRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
+
 
 @CommandRule(LinterSeverity.HIGH)
 def missing_command_help(linter, command_name):

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -173,6 +173,7 @@ def option_should_not_contain_under_score(linter, command_name, parameter_name):
         if '_' in option:
             raise RuleError("Argument's option {} contains '_' which should be '-' instead.".format(option))
 
+
 @ParameterRule(LinterSeverity.HIGH)
 def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
@@ -182,12 +183,14 @@ def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
-                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+
     if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
-                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+
 
 @ParameterRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_parameter(linter, command_name, parameter_name):

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -8,6 +8,8 @@ from knack.deprecation import Deprecated
 
 from ..rule_decorators import ParameterRule
 from ..linter import RuleError, LinterSeverity
+from ..util import has_illegal_html_tag, has_broken_site_links
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
 
 
 @ParameterRule(LinterSeverity.HIGH)
@@ -170,3 +172,36 @@ def option_should_not_contain_under_score(linter, command_name, parameter_name):
             return
         if '_' in option:
             raise RuleError("Argument's option {} contains '_' which should be '-' instead.".format(option))
+
+@ParameterRule(LinterSeverity.HIGH)
+def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
+    if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
+        return
+    help_entry = linter.get_parameter_help_info(command_name, parameter_name)
+
+    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
+        raise RuleError("Command '{}' param '{}' has disallowed html tags in short summary. "
+                        "If tag is a placeholder, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, parameter_name,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
+        raise RuleError("Command '{}'  param '{}' has disallowed html tags in long summary. "
+                        "If tag is a placeholder, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, parameter_name,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+
+@ParameterRule(LinterSeverity.HIGH)
+def broken_site_link_from_parameter(linter, command_name, parameter_name):
+    if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
+        return
+    help_entry = linter.get_parameter_help_info(command_name, parameter_name)
+    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
+        raise RuleError("Command '{}' param '{}' has broken links in short summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, parameter_name,
+                                                                   BROKEN_LINK_RULE_LINK))
+    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
+        raise RuleError("Command '{}' param '{}' has broken links in long summary. "
+                        "If link is an example, please wrap it with backtick. "
+                        "For more info please refer to: {}".format(command_name, parameter_name,
+                                                                   BROKEN_LINK_RULE_LINK))

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -6,10 +6,10 @@
 
 from knack.deprecation import Deprecated
 
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import ParameterRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 
 
 @ParameterRule(LinterSeverity.HIGH)

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -199,11 +199,9 @@ def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
-                                                                           linter.diffed_lines)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
-                                                                          linter.diffed_lines)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -179,13 +179,15 @@ def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
-    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary,
+                                                                             linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in short summary. "
                         "If the content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
-    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary,
+                                                                            linter.diffed_lines)):
         raise RuleError("Disallowed html tags {} in long summary. "
                         "If content is a placeholder, please remove <> or wrap it with backtick. "
                         "For more info please refer to: {}".format(disallowed_tags,
@@ -197,9 +199,11 @@ def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -174,7 +174,7 @@ def option_should_not_contain_under_score(linter, command_name, parameter_name):
             raise RuleError("Argument's option {} contains '_' which should be '-' instead.".format(option))
 
 
-@ParameterRule(LinterSeverity.HIGH)
+@ParameterRule(LinterSeverity.MEDIUM)
 def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
@@ -194,7 +194,7 @@ def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@ParameterRule(LinterSeverity.HIGH)
+@ParameterRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -9,7 +9,7 @@ from knack.deprecation import Deprecated
 from ..rule_decorators import ParameterRule
 from ..linter import RuleError, LinterSeverity
 from ..util import has_illegal_html_tag, has_broken_site_links
-from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK, BROKEN_LINK_RULE_LINK
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 
 
 @ParameterRule(LinterSeverity.HIGH)
@@ -178,30 +178,25 @@ def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary)):
+        raise RuleError("Disallowed html tags {} in short summary. "
+                        "If the content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary)):
+        raise RuleError("Disallowed html tags {} in long summary. "
+                        "If content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
-    if help_entry.short_summary and has_illegal_html_tag(help_entry.short_summary):
-        raise RuleError("Command '{}' param '{}' has disallowed html tags in short summary. "
-                        "If tag is a placeholder, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, parameter_name,
-                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
-    if help_entry.long_summary and has_illegal_html_tag(help_entry.long_summary):
-        raise RuleError("Command '{}'  param '{}' has disallowed html tags in long summary. "
-                        "If tag is a placeholder, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, parameter_name,
-                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
-
-@ParameterRule(LinterSeverity.HIGH)
+@ParameterRule(LinterSeverity.MEDIUM)
 def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
-    if help_entry.short_summary and has_broken_site_links(help_entry.short_summary):
-        raise RuleError("Command '{}' param '{}' has broken links in short summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, parameter_name,
-                                                                   BROKEN_LINK_RULE_LINK))
-    if help_entry.long_summary and has_broken_site_links(help_entry.long_summary):
-        raise RuleError("Command '{}' param '{}' has broken links in long summary. "
-                        "If link is an example, please wrap it with backtick. "
-                        "For more info please refer to: {}".format(command_name, parameter_name,
-                                                                   BROKEN_LINK_RULE_LINK))
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+        raise RuleError("Broken links {} in short summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+        raise RuleError("Broken links {} in long summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -192,7 +192,7 @@ def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
                                                                    DISALLOWED_HTML_TAG_RULE_LINK))
 
 
-@ParameterRule(LinterSeverity.MEDIUM)
+@ParameterRule(LinterSeverity.HIGH)
 def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -122,7 +122,7 @@ class LinterError(Exception):
     pass  # pylint: disable=unnecessary-pass
 
 
-def has_illegal_html_tag(help_message):
+def has_illegal_html_tag(help_message, filtered_lines=None):
     """
     Detect those content wrapped with <> but illegal html tag.
     Refer to rule doc: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main
@@ -131,10 +131,12 @@ def has_illegal_html_tag(help_message):
     unbackticked_matches = [match for match in html_matches if not re.search(r'`[^`]*' + re.escape(match) + r'[^`]*`',
                                                                              help_message)]
     disallowed_html_tags = set(unbackticked_matches) - set(ALLOWED_HTML_TAG)
+    if filtered_lines:
+        disallowed_html_tags = [s for s in disallowed_html_tags if any(s in diff_line for diff_line in filtered_lines)]
     return list(disallowed_html_tags)
 
 
-def has_broken_site_links(help_message):
+def has_broken_site_links(help_message, filtered_lines=None):
     """
     Detect broken link in help message.
     Refer to rule doc: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/other-site-link-broken?branch=main
@@ -152,4 +154,6 @@ def has_broken_site_links(help_message):
         except requests.exceptions.RequestException as ex:
             invalid_urls.append(url)
             print(" exception: {0}, url: {1}".format(str(ex), url))
+    if filtered_lines:
+        invalid_urls = [s for s in invalid_urls if any(s in diff_line for diff_line in filtered_lines)]
     return invalid_urls

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -133,6 +133,7 @@ def has_illegal_html_tag(help_message):
     disallowed_html_tags = set(unbackticked_matches) - set(ALLOWED_HTML_TAG)
     return list(disallowed_html_tags)
 
+
 def has_broken_site_links(help_message):
     """
     Detect broken link in help message.

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -121,19 +121,18 @@ class LinterError(Exception):
     """
     pass  # pylint: disable=unnecessary-pass
 
-
+# pylint: disable=line-too-long
 def has_illegal_html_tag(help_message, filtered_lines=None):
     """
     Detect those content wrapped with <> but illegal html tag.
     Refer to rule doc: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main
     """
     html_matches = re.findall(_HTML_TAG_RE, help_message)
-    unbackticked_matches = [match for match in html_matches if not re.search(r'`[^`]*' + re.escape(match) + r'[^`]*`',
-                                                                             help_message)]
+    unbackticked_matches = [match for match in html_matches if not re.search(r'`[^`]*' + re.escape('<' + match + '>') + r'[^`]*`', help_message)]
     disallowed_html_tags = set(unbackticked_matches) - set(ALLOWED_HTML_TAG)
     if filtered_lines:
-        disallowed_html_tags = [s for s in disallowed_html_tags if any(s in diff_line for diff_line in filtered_lines)]
-    return list(disallowed_html_tags)
+        disallowed_html_tags = [s for s in disallowed_html_tags if any(('<' + s + '>') in diff_line for diff_line in filtered_lines)]
+    return ['<' + s + '>' for s in disallowed_html_tags]
 
 
 def has_broken_site_links(help_message, filtered_lines=None):

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -151,9 +151,8 @@ def has_broken_site_links(help_message, filtered_lines=None):
             if response.status_code != 200:
                 invalid_urls.append(url)
                 print(" status code: {0}, url: {1}".format(response.status_code, url))
-        except requests.exceptions.RequestException as ex:
+        except requests.exceptions.RequestException:
             invalid_urls.append(url)
-            print(" exception: {0}, url: {1}".format(str(ex), url))
     if filtered_lines:
         invalid_urls = [s for s in invalid_urls if any(s in diff_line for diff_line in filtered_lines)]
     return invalid_urls

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -150,7 +150,6 @@ def has_broken_site_links(help_message, filtered_lines=None):
             response = requests.get(url, timeout=5)
             if response.status_code != 200:
                 invalid_urls.append(url)
-                print(" status code: {0}, url: {1}".format(response.status_code, url))
         except requests.exceptions.RequestException:
             invalid_urls.append(url)
     if filtered_lines:

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -143,11 +143,13 @@ def has_broken_site_links(help_message):
     invalid_urls = []
 
     for url in urls:
-        url = url.strip(".,()[]{}<>! ")
+        url = re.sub(r'[.")\'\s]*$', '', url)
         try:
             response = requests.get(url, timeout=5)
             if response.status_code != 200:
                 invalid_urls.append(url)
-        except requests.exceptions.RequestException:
+                print(" status code: {0}, url: {1}".format(response.status_code, url))
+        except requests.exceptions.RequestException as ex:
             invalid_urls.append(url)
+            print(" exception: {0}, url: {1}".format(str(ex), url))
     return invalid_urls

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -21,9 +21,9 @@ _LOADER_CLS_RE = re.compile('.*azure/cli/command_modules/(?P<module>[^/]*)/__ini
 
 # add html tag extraction for <abd>, <lun1>
 # skip html tag search for <edge zone> <os_des>, <lun1_des>
-_HTML_TAG_RE = re.compile('<([^ \n_>]+)>')
+_HTML_TAG_RE = re.compile(r'<([^ \n_>]+)>')
 
-_HTTP_LINK_RE = re.compile('(?<!`)(https?://[^\s`]+)(?!`)')
+_HTTP_LINK_RE = re.compile(r'(?<!`)(https?://[^\s`]+)(?!`)')
 
 
 def filter_modules(command_loader, help_file_entries, modules=None, include_whl_extensions=False):
@@ -147,6 +147,6 @@ def has_broken_site_links(help_message):
             response = requests.get(url, timeout=5)
             if response.status_code != 200:
                 invalid_urls.append(url)
-        except requests.exceptions.RequestException as ex:
+        except requests.exceptions.RequestException:
             invalid_urls.append(url)
     return invalid_urls

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -19,9 +19,9 @@ logger = get_logger(__name__)
 
 _LOADER_CLS_RE = re.compile('.*azure/cli/command_modules/(?P<module>[^/]*)/__init__.*')
 
-# add html tag extraction for <abd>, <lun1>
-# skip html tag search for <edge zone> <os_des>, <lun1_des>
-_HTML_TAG_RE = re.compile(r'<([^ \n_>]+)>')
+# add html tag extraction for <abd>, <lun1>, <edge zone>
+# html tag search for <os_des>, <lun1_des> is enabled in cli ci but skipped in doc build cause internal issue
+_HTML_TAG_RE = re.compile(r'<([^\n>]+)>')
 
 _HTTP_LINK_RE = re.compile(r'(?<!`)(https?://[^\s`]+)(?!`)')
 

--- a/azdev/utilities/__init__.py
+++ b/azdev/utilities/__init__.py
@@ -35,6 +35,7 @@ from .display import (
 from .git_util import (
     diff_branches,
     filter_by_git_diff,
+    diff_branch_file_patch,
     diff_branches_detail
 )
 from .path import (
@@ -94,5 +95,6 @@ __all__ = [
     'require_virtual_env',
     'require_azure_cli',
     'diff_branches_detail',
+    'diff_branch_file_patch',
     'calc_selected_mod_names',
 ]

--- a/azdev/utilities/git_util.py
+++ b/azdev/utilities/git_util.py
@@ -127,3 +127,39 @@ def diff_branches_detail(repo, target, source):
 
     diff_index = target_commit.diff(source_commit)
     return diff_index
+
+
+def diff_branch_file_patch(repo, target, source):
+    """ Returns compare results of files that have changed in a given repo between two branches.
+        Only focus on these files: _params.py, commands.py, test_*.py """
+    try:
+        import git  # pylint: disable=unused-import,unused-variable
+        import git.exc as git_exc
+        import gitdb
+    except ImportError as ex:
+        raise CLIError(ex)
+
+    from git import Repo
+    try:
+        git_repo = Repo(repo)
+    except (git_exc.NoSuchPathError, git_exc.InvalidGitRepositoryError):
+        raise CLIError('invalid git repo: {}'.format(repo))
+
+    def get_commit(branch):
+        try:
+            return git_repo.commit(branch)
+        except gitdb.exc.BadName:
+            raise CLIError('usage error, invalid branch: {}'.format(branch))
+
+    if source:
+        source_commit = get_commit(source)
+    else:
+        source_commit = git_repo.head.commit
+    target_commit = get_commit(target)
+
+    logger.info('Filtering down to modules which have changed based on:')
+    logger.info('cd %s', repo)
+    logger.info('git --no-pager diff %s..%s --name-only -- .\n', target_commit, source_commit)
+
+    diff_index = target_commit.diff(source_commit, create_patch=True)
+    return diff_index


### PR DESCRIPTION
referring to these two rules from learn doc:
1. disallowed html tag: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-attribute?branch=main
2. broken site link: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/other-site-link-broken?branch=main

It's better to have doc checker deployed here but is backloged now for doc builder team. If ready, we can remove these two rules in our repo.

Step 1:
 set severity=Medium to unblock CI
Step 2：
 mitigate current disallowed html tags 
Step 3:
 set severity=High to block any future issues

Besides that, cause cli does not have the knowledge of whether the link is broken or just a placeholder, therefore, the detection on broken link is by module and would require the service owner to fix them