### PR TITLE
Drop Python 3.8 in CI

### DIFF
--- a/azdev/help.py
+++ b/azdev/help.py
@@ -160,7 +160,7 @@ helps['linter'] = """
           text: azdev linter --repo azure-cli --tgt upstream/master --src upstream/dev
 """
 
-helps['scan'] = """
+helps['scan'] = r"""
     short-summary: Scan secrets for files or string
     long-summary: Check built-in scanning rules at https://github.com/microsoft/security-utilities/blob/main/GeneratedRegexPatterns/PreciselyClassifiedSecurityKeys.json
     examples:

--- a/azdev/operations/cmdcov/cmdcov.py
+++ b/azdev/operations/cmdcov/cmdcov.py
@@ -239,8 +239,8 @@ class CmdcovManager:
             self.command_test_coverage['Total'][0] += count
             self.command_test_coverage['Total'][1] += len(self.all_untested_commands[module])
         self.command_test_coverage['Total'][2] = f'''{self.command_test_coverage["Total"][0] /
-                                                 (self.command_test_coverage["Total"][0] +
-                                                  self.command_test_coverage["Total"][1]):.3%}'''
+                                                      (self.command_test_coverage["Total"][0] +
+                                                       self.command_test_coverage["Total"][1]):.3%}'''
         logger.warning(self.command_test_coverage)
         return self.command_test_coverage
 

--- a/azdev/operations/linter/rules/help_rules.py
+++ b/azdev/operations/linter/rules/help_rules.py
@@ -20,10 +20,10 @@ from ..util import LinterError
 
 
 # 'az' space then repeating runs of quoted tokens or non quoted characters
-_az_pattern = 'az\s*' + '(([^\"\'])*|' + '((\"[^\"]*\"\s*)|(\'[^\']*\'\s*))' + ')'  # noqa: W605
+_az_pattern = r'az\s*' + '(([^\"\'])*|' + r'((\"[^\"]*\"\s*)|(\'[^\']*\'\s*))' + ')'
 # match the two types of command substitutions
-_CMD_SUB_1 = re.compile("\$\(\s*" + "(" + _az_pattern + ")" + "\)")  # noqa: W605
-_CMD_SUB_2 = re.compile("`\s*" + "(" + _az_pattern + ")" + "`")  # noqa: W605
+_CMD_SUB_1 = re.compile(r"\$\(\s*" + "(" + _az_pattern + ")" + r"\)")
+_CMD_SUB_2 = re.compile(r"`\s*" + "(" + _az_pattern + ")" + "`")
 
 logger = get_logger(__name__)
 

--- a/azdev/operations/tests/test_scan_and_mask.py
+++ b/azdev/operations/tests/test_scan_and_mask.py
@@ -86,7 +86,7 @@ class TestScanAndMaskSecrets(unittest.TestCase):
         self.assertEqual(len(result['scan_results'][simple_string_file]), 1)
         self.assertEqual(result['scan_results'][simple_string_file][0]['secret_name'], 'AdditionalPattern')
 
-        regex_pattern1 = RegexPattern('(?<refine>[\w.%#+-]+)(%40|@)([a-z0-9.-]*.[a-z]{2,})', '000', 'EmailAddress')
+        regex_pattern1 = RegexPattern(r'(?<refine>[\w.%#+-]+)(%40|@)([a-z0-9.-]*.[a-z]{2,})', '000', 'EmailAddress')
         regex_pattern2 = RegexPattern('(?i)(?:^|[?;&])(?:dsas_secret|sig)=(?<refine>[0-9a-z\\/+%]{43,129}(?:=|%3d))', '001', 'LooseSasSecret')
         with mock.patch("azdev.operations.secret._load_built_in_regex_patterns", return_value=(regex_pattern1, regex_pattern2)):
             result = scan_secrets(file_path=info_json_file)
@@ -153,7 +153,7 @@ class TestScanAndMaskSecrets(unittest.TestCase):
         custom_pattern = {
             "Include": [
                 {
-                    "Pattern": "(?<refine>[\w.%#+-]+)(%40|@)([a-z0-9.-]*.[a-z]{2,})",
+                    "Pattern": r"(?<refine>[\w.%#+-]+)(%40|@)([a-z0-9.-]*.[a-z]{2,})",
                     "Name": "EmailAddress"
                 }
             ]

--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -33,9 +33,9 @@ jobs:
     name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.8'
+    displayName: 'Use Python 3.12'
     inputs:
-      versionSpec: 3.8
+      versionSpec: 3.12
 
   - task: Bash@3
     displayName: 'Run Wheel Build Script'
@@ -57,9 +57,9 @@ jobs:
     name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.8'
+    displayName: 'Use Python 3.12'
     inputs:
-      versionSpec: 3.8
+      versionSpec: 3.12
 
   - task: Bash@3
     displayName: 'Run Wheel Build Script'
@@ -80,10 +80,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -137,10 +137,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -169,10 +169,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -201,10 +201,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -233,10 +233,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -264,10 +264,10 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python312:
+        python.version: '3.12'
   steps:
     - task: DownloadPipelineArtifact@1
       displayName: 'Download Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,15 +12,18 @@ jobs:
     name: 'pool-ubuntu-2004'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
-        tox_env: 'py38'
       Python39:
         python.version: '3.9'
         tox_env: 'py39'
       Python310:
         python.version: '3.10'
         tox_env: 'py310'
+      Python311:
+        python.version: '3.11'
+        tox_env: 'py311'
+      Python312:
+        python.version: '3.12'
+        tox_env: 'py312'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python $(python.version)'
@@ -85,9 +88,9 @@ jobs:
     name: 'pool-ubuntu-2004'
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.8'
+    displayName: 'Use Python 3.12'
     inputs:
-      versionSpec: 3.8
+      versionSpec: 3.12
 
   - task: Bash@3
     displayName: 'Run Wheel Build Script'


### PR DESCRIPTION
3.8 is dropped in https://github.com/Azure/azure-cli/pull/30225.
Update the related task to use newer python version.