### PR TITLE
Add html tag and broken link detection in linter

### DIFF
--- a/azdev/operations/constant.py
+++ b/azdev/operations/constant.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -----------------------------------------------------------------------------
+# pylint: disable=line-too-long
 
 ENCODING = 'utf-8'
 
@@ -78,6 +79,23 @@ EXCLUDE_MODULES = [
     'kusto',
     'util'
 ]
+
+# refer to doc: https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies/allowed-html?branch=main
+ALLOWED_HTML_TAG = [
+    "a", "address", "article", "b", "blockquote", "br", "button", "br /",
+    "caption", "center", "cite", "code", "col", "colgroup",
+    "dd", "del", "details", "div", "dl", "dt", "em", "figcaption", "figure", "form",
+    "h1", "h2", "h3", "h4", "head", "hr",
+    "i", "iframe", "image", "img", "input", "ins", "kbd",
+    "label", "li", "nav", "nobr", "ol", "p", "pre", "rgn",
+    "s", "section", "source", "span", "strike", "strong", "sub", "summary", "sup",
+    "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+    "u", "ul", "wbr"
+]
+
+DISALLOWED_HTML_TAG_RULE_LINK = "https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-tag?branch=main"
+
+BROKEN_LINK_RULE_LINK = "https://review.learn.microsoft.com/en-us/help/platform/validation-ref/other-site-link-broken?branch=main"
 
 GLOBAL_EXCLUDE_COMMANDS = ['wait']
 

--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -3,9 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # -----------------------------------------------------------------------------
+# pylint: disable=duplicate-code
 
+from azdev.operations.constant import DISALLOWED_HTML_TAG_RULE_LINK
 from ..rule_decorators import CommandGroupRule
 from ..linter import RuleError, LinterSeverity
+from ..util import has_illegal_html_tag, has_broken_site_links
 
 
 @CommandGroupRule(LinterSeverity.HIGH)
@@ -40,3 +43,35 @@ def require_wait_command_if_no_wait(linter, command_group_name):
     for cmd in group_command_names:
         if linter.get_command_metadata(cmd).supports_no_wait:
             raise RuleError("Group does not have a 'wait' command, yet '{}' exposes '--no-wait'".format(cmd))
+
+
+@CommandGroupRule(LinterSeverity.MEDIUM)
+def disallowed_html_tag_from_command_group(linter, command_group_name):
+    if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_group_name)
+    if help_entry.short_summary and (disallowed_tags := has_illegal_html_tag(help_entry.short_summary,
+                                                                             linter.diffed_lines)):
+        raise RuleError("Disallowed html tags {} in short summary. "
+                        "If the content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+    if help_entry.long_summary and (disallowed_tags := has_illegal_html_tag(help_entry.long_summary,
+                                                                            linter.diffed_lines)):
+        raise RuleError("Disallowed html tags {} in long summary. "
+                        "If content is a placeholder, please remove <> or wrap it with backtick. "
+                        "For more info please refer to: {}".format(disallowed_tags,
+                                                                   DISALLOWED_HTML_TAG_RULE_LINK))
+
+
+@CommandGroupRule(LinterSeverity.MEDIUM)
+def broken_site_link_from_command_group(linter, command_group_name):
+    if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
+        return
+    help_entry = linter.get_loaded_help_entry(command_group_name)
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+        raise RuleError("Broken links {} in short summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+        raise RuleError("Broken links {} in long summary. "
+                        "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/utilities/__init__.py
+++ b/azdev/utilities/__init__.py
@@ -35,6 +35,7 @@ from .display import (
 from .git_util import (
     diff_branches,
     filter_by_git_diff,
+    diff_branch_file_patch,
     diff_branches_detail
 )
 from .path import (
@@ -94,5 +95,6 @@ __all__ = [
     'require_virtual_env',
     'require_azure_cli',
     'diff_branches_detail',
+    'diff_branch_file_patch',
     'calc_selected_mod_names',
 ]

--- a/azdev/utilities/git_util.py
+++ b/azdev/utilities/git_util.py
@@ -127,3 +127,39 @@ def diff_branches_detail(repo, target, source):
 
     diff_index = target_commit.diff(source_commit)
     return diff_index
+
+
+def diff_branch_file_patch(repo, target, source):
+    """ Returns compare results of files that have changed in a given repo between two branches.
+        Only focus on these files: _params.py, commands.py, test_*.py """
+    try:
+        import git  # pylint: disable=unused-import,unused-variable
+        import git.exc as git_exc
+        import gitdb
+    except ImportError as ex:
+        raise CLIError(ex)
+
+    from git import Repo
+    try:
+        git_repo = Repo(repo)
+    except (git_exc.NoSuchPathError, git_exc.InvalidGitRepositoryError):
+        raise CLIError('invalid git repo: {}'.format(repo))
+
+    def get_commit(branch):
+        try:
+            return git_repo.commit(branch)
+        except gitdb.exc.BadName:
+            raise CLIError('usage error, invalid branch: {}'.format(branch))
+
+    if source:
+        source_commit = get_commit(source)
+    else:
+        source_commit = git_repo.head.commit
+    target_commit = get_commit(target)
+
+    logger.info('Filtering down to modules which have changed based on:')
+    logger.info('cd %s', repo)
+    logger.info('git --no-pager diff %s..%s --name-only -- .\n', target_commit, source_commit)
+
+    diff_index = target_commit.diff(source_commit, create_patch=True)
+    return diff_index


### PR DESCRIPTION
Referring to these two rules from learn doc:
1. disallowed html tag: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/disallowed-html-attribute?branch=main
2. broken site link: https://review.learn.microsoft.com/en-us/help/platform/validation-ref/other-site-link-broken?branch=main

It's better to have doc checker deployed here but is backloged now for doc builder team. If ready, we can remove these two rules in our repo.

Step 1:
 set severity=Medium to unblock CI
Step 2：
 mitigate current disallowed html tags 
Step 3:
 set severity=High to block any future issues

Besides that, cause cli does not have the knowledge of whether the link is broken or just a placeholder, therefore, the detection on broken link is by module and would require the service owner to fix them