### PR TITLE
turn on disallowed html tags and filter broken site link

### DIFF
--- a/azdev/operations/linter/rules/command_group_rules.py
+++ b/azdev/operations/linter/rules/command_group_rules.py
@@ -45,7 +45,7 @@ def require_wait_command_if_no_wait(linter, command_group_name):
             raise RuleError("Group does not have a 'wait' command, yet '{}' exposes '--no-wait'".format(cmd))
 
 
-@CommandGroupRule(LinterSeverity.MEDIUM)
+@CommandGroupRule(LinterSeverity.HIGH)
 def disallowed_html_tag_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
@@ -69,9 +69,11 @@ def broken_site_link_from_command_group(linter, command_group_name):
     if command_group_name == '' or not linter.get_loaded_help_entry(command_group_name):
         return
     help_entry = linter.get_loaded_help_entry(command_group_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/command_rules.py
+++ b/azdev/operations/linter/rules/command_rules.py
@@ -40,7 +40,7 @@ def group_delete_commands_should_confirm(linter, command_name):
                             "Please make sure to ask for confirmation.")
 
 
-@CommandRule(LinterSeverity.MEDIUM)
+@CommandRule(LinterSeverity.HIGH)
 def disallowed_html_tag_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
@@ -64,9 +64,11 @@ def broken_site_link_from_command(linter, command_name):
     if command_name == '' or not linter.get_loaded_help_entry(command_name):
         return
     help_entry = linter.get_loaded_help_entry(command_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))

--- a/azdev/operations/linter/rules/parameter_rules.py
+++ b/azdev/operations/linter/rules/parameter_rules.py
@@ -174,7 +174,7 @@ def option_should_not_contain_under_score(linter, command_name, parameter_name):
             raise RuleError("Argument's option {} contains '_' which should be '-' instead.".format(option))
 
 
-@ParameterRule(LinterSeverity.MEDIUM)
+@ParameterRule(LinterSeverity.HIGH)
 def disallowed_html_tag_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
@@ -199,9 +199,11 @@ def broken_site_link_from_parameter(linter, command_name, parameter_name):
     if linter.command_expired(command_name) or not linter.get_parameter_help_info(command_name, parameter_name):
         return
     help_entry = linter.get_parameter_help_info(command_name, parameter_name)
-    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary)):
+    if help_entry.short_summary and (broken_links := has_broken_site_links(help_entry.short_summary,
+                                                                           linter.diffed_lines)):
         raise RuleError("Broken links {} in short summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))
-    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary)):
+    if help_entry.long_summary and (broken_links := has_broken_site_links(help_entry.long_summary,
+                                                                          linter.diffed_lines)):
         raise RuleError("Broken links {} in long summary. "
                         "If link is an example, please wrap it with backtick. ".format(broken_links))


### PR DESCRIPTION
According to https://github.com/Azure/azure-cli-dev-tools/pull/488, turn on disallowed html tag detection with severity high.

To ensure not blocking module developers, add filtering by diff code for broken site link detection too. Therefore, existing broken site links (roughly 70 broken site links failures in cli repo) need to be handled either by cli or corresponding service team. Broken site link is marked as suggestion in doc build report.  

Step 1:
set severity=Medium to unblock CI
Step 2：
mitigate current disallowed html tags
**Step 3:
set severity=High to block any future issues**