### PR TITLE
add example missing check

### DIFF
--- a/azdev/operations/constant.py
+++ b/azdev/operations/constant.py
@@ -4,7 +4,7 @@
 # license information.
 # -----------------------------------------------------------------------------
 # pylint: disable=line-too-long
-
+import os
 ENCODING = 'utf-8'
 
 # Base on https://github.com/Azure/azure-cli/blob/dev/.github/CODEOWNERS
@@ -259,3 +259,8 @@ VERSION_PREVIEW_TAG = "preview"
 PREVIEW_INIT_SUFFIX = "b1"
 
 CLI_EXTENSION_INDEX_URL = "https://azcliextensionsync.blob.core.windows.net/index1/index.json"
+
+CMD_EXAMPLE_CONFIG_FILE = "./data/cmd_example_config.json"
+CMD_EXAMPLE_CONFIG_FILE_PATH = f"{os.path.dirname(os.path.realpath(__file__))}/linter/{CMD_EXAMPLE_CONFIG_FILE}"
+CMD_EXAMPLE_CONFIG_FILE_URL = "https://azcmdchangemgmt.blob.core.windows.net/azure-cli-dev-tool-config/cmd_example_config.json"
+CMD_EXAMPLE_DEFAULT = 1

--- a/azdev/operations/linter/data/cmd_example_config.json
+++ b/azdev/operations/linter/data/cmd_example_config.json
@@ -1,0 +1,10 @@
+{
+  "create": 1,
+  "add": 1,
+  "update": 1,
+  "list": 0,
+  "delete": 0,
+  "remove": 0,
+  "show": 0,
+  "wait": 0
+}

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -247,7 +247,7 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
                 violations.append(f'Command `{cmd}` should have at least {cmd_example_threshold} example(s)')
         if violations:
             violations.insert(0, 'Check command example failed.')
-            violations.extend(['Please add examples for the modified command Or add the command in rule_exclusions: missing_command_example in linter_exclusions.yml'])
+            violations.extend(['Please add examples for the modified command or add the command in rule_exclusions: missing_command_example in linter_exclusions.yml'])
         return violations
 
     def _get_exclusions(self):

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -437,7 +437,7 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
             lines = list(context_diff(original_lines, current_lines, 'Original', 'Current'))
 
             if 'commands.py' in filename:
-                for row_num, line in enumerate(lines):
+                for _, line in enumerate(lines):
                     aaz_custom_command = search_aaz_custom_command(line)
                     if aaz_custom_command:
                         added_commands.add(aaz_custom_command)

--- a/azdev/operations/linter/linter.py
+++ b/azdev/operations/linter/linter.py
@@ -427,7 +427,7 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
 
     def _detect_modified_aaz_command(self):
         diff_index = diff_branches_detail(repo=self.git_repo, target=self.git_target, source=self.git_source)
-        added_commands = set()
+        modified_commands = set()
         for diff in diff_index:
             file_path, filename = self._split_path(diff.a_path)
             if "aaz" not in file_path or "commands.py" not in filename:
@@ -440,15 +440,15 @@ class Linter:  # pylint: disable=too-many-public-methods, too-many-instance-attr
                 for _, line in enumerate(lines):
                     aaz_custom_command = search_aaz_custom_command(line)
                     if aaz_custom_command:
-                        added_commands.add(aaz_custom_command)
+                        modified_commands.add(aaz_custom_command)
 
             if "aaz" in file_path:
                 aaz_raw_command = search_aaz_raw_command(lines)
                 if aaz_raw_command:
-                    added_commands.add(aaz_raw_command)
+                    modified_commands.add(aaz_raw_command)
 
-        commands = list(added_commands)
-        _logger.debug('Added commands: %s', added_commands)
+        commands = list(modified_commands)
+        _logger.debug('Modified commands: %s', modified_commands)
         return commands
 
     def _get_diffed_patches(self):

--- a/azdev/operations/linter/rules/command_coverage_rules.py
+++ b/azdev/operations/linter/rules/command_coverage_rules.py
@@ -22,3 +22,10 @@ def missing_parameter_test_coverage(linter):
     if not exec_state:
         violation_msg = "\n\t".join(violations)
         raise RuleError(violation_msg + "\n")
+
+@CommandCoverageRule(LinterSeverity.HIGH)
+def missing_command_example(linter):
+    violations = linter.check_missing_command_example()
+    if violations:
+        violation_msg = "\n\t".join(violations)
+        raise RuleError(violation_msg + "\n")

--- a/azdev/operations/linter/rules/command_coverage_rules.py
+++ b/azdev/operations/linter/rules/command_coverage_rules.py
@@ -23,6 +23,7 @@ def missing_parameter_test_coverage(linter):
         violation_msg = "\n\t".join(violations)
         raise RuleError(violation_msg + "\n")
 
+
 @CommandCoverageRule(LinterSeverity.HIGH)
 def missing_command_example(linter):
     violations = linter.check_missing_command_example()

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -172,7 +172,7 @@ def get_cmd_example_configurations():
             cmd_example_threshold = json.load(f_in)
     else:
         logger.info("remote cmd example configuration fetch success")
-        cmd_example_threshold = remote_res.json
+        cmd_example_threshold = remote_res.json()
     return cmd_example_threshold
 
 

--- a/azdev/operations/linter/util.py
+++ b/azdev/operations/linter/util.py
@@ -6,9 +6,9 @@
 
 import copy
 import re
-import requests
 import os
 import json
+import requests
 
 from knack.log import get_logger
 
@@ -167,7 +167,7 @@ def get_cmd_example_configurations():
         logger.warning("remote cmd example configuration fetch error, use local dict")
         if not os.path.exists(CMD_EXAMPLE_CONFIG_FILE_PATH):
             logger.info("cmd_example_config.json not exist, skipped")
-            return
+            return cmd_example_threshold
         with open(CMD_EXAMPLE_CONFIG_FILE_PATH, "r") as f_in:
             cmd_example_threshold = json.load(f_in)
     else:

--- a/azdev/operations/regex.py
+++ b/azdev/operations/regex.py
@@ -173,3 +173,31 @@ def search_deleted_command(line):
     if ref:
         command = ref[0].split(',')[0].strip("'")
     return command
+
+
+def search_aaz_custom_command(line):
+    """
+    re match pattern
+    +   self.command_table['monitor autoscale update'] = AutoScaleUpdate(loader=self)
+    """
+    cmd = ''
+    aaz_custom_cmd_pattern = r"\+.*\.command_table\[['\"](.*?)['\"]\]"
+    ref = re.findall(aaz_custom_cmd_pattern, line)
+    if ref:
+        cmd = ref[0].strip()
+    return cmd
+
+
+def search_aaz_raw_command(lines):
+    """
+    re match pattern
+    +@register_command(
+    +      "monitor autoscale update",
+    +)
+    """
+    cmd = ''
+    aaz_raw_cmd_pattern = r"\+@register_command\([\s\S]*?\+.*?['\"](.*?)['\"]"
+    ref = re.findall(aaz_raw_cmd_pattern, lines)
+    if ref:
+        cmd = ref[0].strip()
+    return cmd

--- a/azdev/operations/regex.py
+++ b/azdev/operations/regex.py
@@ -197,7 +197,7 @@ def search_aaz_raw_command(lines):
     """
     cmd = ''
     aaz_raw_cmd_pattern = r"\+@register_command\([\s\S]*?\+.*?['\"](.*?)['\"]"
-    ref = re.findall(aaz_raw_cmd_pattern, lines)
+    ref = re.findall(aaz_raw_cmd_pattern, str(lines))
     if ref:
         cmd = ref[0].strip()
     return cmd

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'azdev.config': ['*.*', 'cli_pylintrc', 'ext_pylintrc'],
         'azdev.mod_templates': ['*.*'],
         'azdev.operations.linter.rules': ['ci_exclusions.yml'],
+        'azdev.operations.linter': ["data/*"],
         'azdev.operations.cmdcov': ['*.*'],
         'azdev.operations.breaking_change': ['*.*'],
     },


### PR DESCRIPTION
We plan to add two example checks for cmd.

1. for added or modified cmds, check the basic example requirement
2. for existing cmds, check the cmd example with corresponding telemetry data and request for adding missing parameter set examples.

This pr is for task 1.