### PR TITLE
Enable meta diff with different mod name

### DIFF
--- a/azure-cli-diff-tool/HISTORY.rst
+++ b/azure-cli-diff-tool/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.1.0
+++++++
+* Use dynamic metadata whitelist
+
 0.0.9
 ++++++
 * Use dynamic metadata whitelist

--- a/azure-cli-diff-tool/HISTORY.rst
+++ b/azure-cli-diff-tool/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 0.1.0
 ++++++
-* Use dynamic metadata whitelist
+* Enable meta-diff with `module_name` excluded
 
 0.0.9
 ++++++

--- a/azure-cli-diff-tool/azure_cli_diff_tool/__init__.py
+++ b/azure-cli-diff-tool/azure_cli_diff_tool/__init__.py
@@ -18,7 +18,7 @@ from .utils import get_blob_config, load_blob_config_file, get_target_version_mo
     extract_module_name_from_meta_file, export_meta_changes_to_csv, export_meta_changes_to_json, \
     export_meta_changes_to_dict, expand_deprecate_obj
 
-__VERSION__ = '0.0.9'
+__VERSION__ = '0.1.0'
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def meta_diff(base_meta_file, diff_meta_file, only_break=False, output_type="tex
         raise Exception("Please update your azure cli diff tool")
     expand_deprecate_obj(command_tree_before)
     expand_deprecate_obj(command_tree_after)
-    diff = DeepDiff(command_tree_before, command_tree_after)
+    diff = DeepDiff(command_tree_before, command_tree_after, exclude_paths=["root['module_name']"])
     if not diff:
         print(f"No meta diffs from {diff_meta_file} to {base_meta_file}")
         return export_meta_changes_to_json(None, output_file)

--- a/azure-cli-diff-tool/azure_cli_diff_tool/meta_change_detect.py
+++ b/azure-cli-diff-tool/azure_cli_diff_tool/meta_change_detect.py
@@ -45,8 +45,10 @@ class MetaChangeDetect:
             self.deep_diff = deep_diff
         else:
             logger.info("None diffs from cmd meta json")
-        assert base_meta["module_name"] == diff_meta["module_name"]
-        self.module_name = base_meta["module_name"]
+        if base_meta["module_name"] != diff_meta["module_name"]:
+            print(f'Comparing two modules with different name, base mod: {base_meta["module_name"]},'
+                  f' diff mod: {diff_meta["module_name"]}')
+        self.module_name = diff_meta["module_name"]
         self.base_meta = base_meta
         self.diff_meta = diff_meta
         self.diff_objs = []

--- a/azure-cli-diff-tool/tests/jsons/az_network-manager_meta_after.json
+++ b/azure-cli-diff-tool/tests/jsons/az_network-manager_meta_after.json
@@ -1,0 +1,4810 @@
+{
+    "module_name": "network-manager",
+    "name": "az",
+    "commands": {},
+    "sub_groups": {
+        "network": {
+            "name": "network",
+            "commands": {},
+            "sub_groups": {
+                "network manager": {
+                    "name": "network manager",
+                    "commands": {
+                        "network manager create": {
+                            "name": "network manager create",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group_name",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "type": "string",
+                                "required": true,
+                                "id_part": "name"
+                            }, {
+                                "name": "location",
+                                "options": ["--location", "-l"],
+                                "type": "custom_type",
+                                "required": true,
+                                "has_completer": true
+                            }, {
+                                "name": "module_name",
+                                "options": ["--network-manager-scopes"],
+                                "required": true,
+                                "nargs": "+"
+                            }, {
+                                "name": "network_manager_scope_accesses",
+                                "options": ["--scope-accesses"],
+                                "required": true,
+                                "nargs": "+"
+                            }, {
+                                "name": "id_",
+                                "options": ["--id"],
+                                "type": "string"
+                            }, {
+                                "name": "tags",
+                                "options": ["--tags"],
+                                "nargs": "*"
+                            }, {
+                                "name": "description",
+                                "options": ["--description"],
+                                "type": "string"
+                            }]
+                        },
+                        "network manager delete": {
+                            "name": "network manager delete",
+                            "is_aaz": true,
+                            "supports_no_wait": true,
+                            "parameters": [{
+                                "name": "no_wait",
+                                "options": ["--no-wait"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "force",
+                                "options": ["--force"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "yes",
+                                "options": ["--yes", "-y"]
+                            }]
+                        },
+                        "network manager list": {
+                            "name": "network manager list",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "pagination_token",
+                                "options": ["--next-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "pagination_limit",
+                                "options": ["--max-items"],
+                                "aaz_type": "int",
+                                "type": "int"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "top",
+                                "options": ["--top"],
+                                "aaz_type": "int",
+                                "type": "int"
+                            }]
+                        },
+                        "network manager list-active-connectivity-config": {
+                            "name": "network manager list-active-connectivity-config",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-active-security-admin-rule": {
+                            "name": "network manager list-active-security-admin-rule",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-deploy-status": {
+                            "name": "network manager list-deploy-status",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "deployment_types",
+                                "options": ["--deployment-types"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-effective-connectivity-config": {
+                            "name": "network manager list-effective-connectivity-config",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "virtual_network_name",
+                                "options": ["--virtual-network-name", "--vnet-name"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-effective-security-admin-rule": {
+                            "name": "network manager list-effective-security-admin-rule",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "virtual_network_name",
+                                "options": ["--virtual-network-name", "--vnet-name"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager post-commit": {
+                            "name": "network manager post-commit",
+                            "is_aaz": true,
+                            "supports_no_wait": true,
+                            "parameters": [{
+                                "name": "no_wait",
+                                "options": ["--no-wait"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "commit_type",
+                                "options": ["--commit-type"],
+                                "required": true,
+                                "choices": ["Connectivity", "Routing", "SecurityAdmin", "SecurityUser"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "configuration_ids",
+                                "options": ["--configuration-ids"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "target_locations",
+                                "options": ["--target-locations"],
+                                "required": true,
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }]
+                        },
+                        "network manager show": {
+                            "name": "network manager show",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager update": {
+                            "name": "network manager update",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group_name",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "type": "string",
+                                "required": true,
+                                "id_part": "name"
+                            }, {
+                                "name": "id_",
+                                "options": ["--id"],
+                                "type": "string"
+                            }, {
+                                "name": "location",
+                                "options": ["--location", "-l"],
+                                "type": "custom_type",
+                                "has_completer": true
+                            }, {
+                                "name": "tags",
+                                "options": ["--tags"],
+                                "nargs": "*"
+                            }, {
+                                "name": "description",
+                                "options": ["--description"],
+                                "type": "string"
+                            }, {
+                                "name": "network_manager_scopes",
+                                "options": ["--network-manager-scopes"],
+                                "nargs": "+"
+                            }, {
+                                "name": "network_manager_scope_accesses",
+                                "options": ["--scope-accesses"],
+                                "nargs": "+"
+                            }]
+                        },
+                        "network manager wait": {
+                            "name": "network manager wait",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "timeout",
+                                "options": ["--timeout"],
+                                "type": "int",
+                                "default": 3600
+                            }, {
+                                "name": "interval",
+                                "options": ["--interval"],
+                                "type": "int",
+                                "default": 30
+                            }, {
+                                "name": "deleted",
+                                "options": ["--deleted"]
+                            }, {
+                                "name": "created",
+                                "options": ["--created"]
+                            }, {
+                                "name": "updated",
+                                "options": ["--updated"]
+                            }, {
+                                "name": "exists",
+                                "options": ["--exists"]
+                            }, {
+                                "name": "custom",
+                                "options": ["--custom"]
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        }
+                    },
+                    "sub_groups": {
+                        "network manager connection": {
+                            "name": "network manager connection",
+                            "commands": {},
+                            "sub_groups": {
+                                "network manager connection management-group": {
+                                    "name": "network manager connection management-group",
+                                    "commands": {
+                                        "network manager connection management-group create": {
+                                            "name": "network manager connection management-group create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_id",
+                                                "options": ["--network-manager", "--network-manager-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection management-group delete": {
+                                            "name": "network manager connection management-group delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager connection management-group list": {
+                                            "name": "network manager connection management-group list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager connection management-group show": {
+                                            "name": "network manager connection management-group show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection management-group update": {
+                                            "name": "network manager connection management-group update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                },
+                                "network manager connection subscription": {
+                                    "name": "network manager connection subscription",
+                                    "commands": {
+                                        "network manager connection subscription create": {
+                                            "name": "network manager connection subscription create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_id",
+                                                "options": ["--network-manager", "--network-manager-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection subscription delete": {
+                                            "name": "network manager connection subscription delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager connection subscription list": {
+                                            "name": "network manager connection subscription list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager connection subscription show": {
+                                            "name": "network manager connection subscription show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection subscription update": {
+                                            "name": "network manager connection subscription update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager connect-config": {
+                            "name": "network manager connect-config",
+                            "commands": {
+                                "network manager connect-config create": {
+                                    "name": "network manager connect-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "applies_to_groups",
+                                        "options": ["--applies-to-group", "--applies-to-groups"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "connectivity_topology",
+                                        "options": ["--connectivity-topology"],
+                                        "choices": ["HubAndSpoke", "Mesh"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "delete_existing_peering",
+                                        "options": ["--delete-existing-peering"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "hubs",
+                                        "options": ["--hub", "--hubs"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "is_global",
+                                        "options": ["--is-global"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config delete": {
+                                    "name": "network manager connect-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager connect-config list": {
+                                    "name": "network manager connect-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager connect-config show": {
+                                    "name": "network manager connect-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config update": {
+                                    "name": "network manager connect-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "applies_to_groups",
+                                        "options": ["--applies-to-group", "--applies-to-groups"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "connectivity_topology",
+                                        "options": ["--connectivity-topology"],
+                                        "choices": ["HubAndSpoke", "Mesh"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "delete_existing_peering",
+                                        "options": ["--delete-existing-peering"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "hubs",
+                                        "options": ["--hub", "--hubs"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "is_global",
+                                        "options": ["--is-global"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config wait": {
+                                    "name": "network manager connect-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {}
+                        },
+                        "network manager group": {
+                            "name": "network manager group",
+                            "commands": {
+                                "network manager group create": {
+                                    "name": "network manager group create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "if_match",
+                                        "options": ["--if-match"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group delete": {
+                                    "name": "network manager group delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager group list": {
+                                    "name": "network manager group list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager group show": {
+                                    "name": "network manager group show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group update": {
+                                    "name": "network manager group update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "if_match",
+                                        "options": ["--if-match"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group wait": {
+                                    "name": "network manager group wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager group static-member": {
+                                    "name": "network manager group static-member",
+                                    "commands": {
+                                        "network manager group static-member create": {
+                                            "name": "network manager group static-member create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_id",
+                                                "options": ["--resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager group static-member delete": {
+                                            "name": "network manager group static-member delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager group static-member list": {
+                                            "name": "network manager group static-member list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager group static-member show": {
+                                            "name": "network manager group static-member show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager ipam-pool": {
+                            "name": "network manager ipam-pool",
+                            "commands": {
+                                "network manager ipam-pool create": {
+                                    "name": "network manager ipam-pool create",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "location",
+                                        "options": ["--location", "-l"],
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "address_prefixes",
+                                        "options": ["--address-prefixes"],
+                                        "required": true,
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "display_name",
+                                        "options": ["--display-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "parent_pool_name",
+                                        "options": ["--parent-pool-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool delete": {
+                                    "name": "network manager ipam-pool delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager ipam-pool get-pool-usage": {
+                                    "name": "network manager ipam-pool get-pool-usage",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool list": {
+                                    "name": "network manager ipam-pool list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip",
+                                        "options": ["--skip"],
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 0
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_key",
+                                        "options": ["--sort-key"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_value",
+                                        "options": ["--sort-value"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "default": 50,
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 50
+                                    }]
+                                },
+                                "network manager ipam-pool list-associated-resource": {
+                                    "name": "network manager ipam-pool list-associated-resource",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool show": {
+                                    "name": "network manager ipam-pool show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool update": {
+                                    "name": "network manager ipam-pool update",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "display_name",
+                                        "options": ["--display-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool wait": {
+                                    "name": "network manager ipam-pool wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager ipam-pool static-cidr": {
+                                    "name": "network manager ipam-pool static-cidr",
+                                    "commands": {
+                                        "network manager ipam-pool static-cidr create": {
+                                            "name": "network manager ipam-pool static-cidr create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "address_prefixes",
+                                                "options": ["--address-prefixes"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<String>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "number_of_ip_addresses_to_allocate",
+                                                "options": ["--allocate", "--number-of-ip-addresses-to-allocate", "-a"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr delete": {
+                                            "name": "network manager ipam-pool static-cidr delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr list": {
+                                            "name": "network manager ipam-pool static-cidr list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr show": {
+                                            "name": "network manager ipam-pool static-cidr show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr wait": {
+                                            "name": "network manager ipam-pool static-cidr wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager routing-config": {
+                            "name": "network manager routing-config",
+                            "commands": {
+                                "network manager routing-config create": {
+                                    "name": "network manager routing-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config delete": {
+                                    "name": "network manager routing-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager routing-config list": {
+                                    "name": "network manager routing-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager routing-config show": {
+                                    "name": "network manager routing-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config update": {
+                                    "name": "network manager routing-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config wait": {
+                                    "name": "network manager routing-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager routing-config rule-collection": {
+                                    "name": "network manager routing-config rule-collection",
+                                    "commands": {
+                                        "network manager routing-config rule-collection create": {
+                                            "name": "network manager routing-config rule-collection create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to",
+                                                "options": ["--applies-to"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<Object>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "disable_bgp_route",
+                                                "options": ["--disable-bgp-route"],
+                                                "choices": ["False", "True"],
+                                                "default": "true",
+                                                "aaz_type": "string",
+                                                "type": "string",
+                                                "aaz_default": "true"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection delete": {
+                                            "name": "network manager routing-config rule-collection delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "force",
+                                                "options": ["--force"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection list": {
+                                            "name": "network manager routing-config rule-collection list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection show": {
+                                            "name": "network manager routing-config rule-collection show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection update": {
+                                            "name": "network manager routing-config rule-collection update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to",
+                                                "options": ["--applies-to"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<Object>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "disable_bgp_route",
+                                                "options": ["--disable-bgp-route"],
+                                                "choices": ["False", "True"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection wait": {
+                                            "name": "network manager routing-config rule-collection wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {
+                                        "network manager routing-config rule-collection rule": {
+                                            "name": "network manager routing-config rule-collection rule",
+                                            "commands": {
+                                                "network manager routing-config rule-collection rule create": {
+                                                    "name": "network manager routing-config rule-collection rule create",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "destination",
+                                                        "options": ["--destination"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }, {
+                                                        "name": "next_hop",
+                                                        "options": ["--next-hop"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule delete": {
+                                                    "name": "network manager routing-config rule-collection rule delete",
+                                                    "is_aaz": true,
+                                                    "supports_no_wait": true,
+                                                    "parameters": [{
+                                                        "name": "no_wait",
+                                                        "options": ["--no-wait"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "force",
+                                                        "options": ["--force"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "yes",
+                                                        "options": ["--yes", "-y"]
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule list": {
+                                                    "name": "network manager routing-config rule-collection rule list",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "pagination_token",
+                                                        "options": ["--next-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "pagination_limit",
+                                                        "options": ["--max-items"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "skip_token",
+                                                        "options": ["--skip-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "top",
+                                                        "options": ["--top"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule show": {
+                                                    "name": "network manager routing-config rule-collection rule show",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule update": {
+                                                    "name": "network manager routing-config rule-collection rule update",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "generic_update_add",
+                                                        "options": ["--add"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                                    }, {
+                                                        "name": "generic_update_set",
+                                                        "options": ["--set"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                                    }, {
+                                                        "name": "generic_update_remove",
+                                                        "options": ["--remove"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                                    }, {
+                                                        "name": "generic_update_force_string",
+                                                        "options": ["--force-string"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "destination",
+                                                        "options": ["--destination"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }, {
+                                                        "name": "next_hop",
+                                                        "options": ["--next-hop"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule wait": {
+                                                    "name": "network manager routing-config rule-collection rule wait",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "timeout",
+                                                        "options": ["--timeout"],
+                                                        "type": "int",
+                                                        "default": 3600
+                                                    }, {
+                                                        "name": "interval",
+                                                        "options": ["--interval"],
+                                                        "type": "int",
+                                                        "default": 30
+                                                    }, {
+                                                        "name": "deleted",
+                                                        "options": ["--deleted"]
+                                                    }, {
+                                                        "name": "created",
+                                                        "options": ["--created"]
+                                                    }, {
+                                                        "name": "updated",
+                                                        "options": ["--updated"]
+                                                    }, {
+                                                        "name": "exists",
+                                                        "options": ["--exists"]
+                                                    }, {
+                                                        "name": "custom",
+                                                        "options": ["--custom"]
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                }
+                                            },
+                                            "sub_groups": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "network manager scope-connection": {
+                            "name": "network manager scope-connection",
+                            "commands": {
+                                "network manager scope-connection create": {
+                                    "name": "network manager scope-connection create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_id",
+                                        "options": ["--resource-id"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tenant_id",
+                                        "options": ["--tenant-id"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager scope-connection delete": {
+                                    "name": "network manager scope-connection delete",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager scope-connection list": {
+                                    "name": "network manager scope-connection list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager scope-connection show": {
+                                    "name": "network manager scope-connection show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager scope-connection update": {
+                                    "name": "network manager scope-connection update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {}
+                        },
+                        "network manager security-admin-config": {
+                            "name": "network manager security-admin-config",
+                            "commands": {
+                                "network manager security-admin-config create": {
+                                    "name": "network manager security-admin-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "apply_on_network_intent_policy",
+                                        "options": ["--apply-on", "--apply-on-network-intent-policy"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_address_space_aggregation_option",
+                                        "options": ["--aggregation", "--network-group-address-space-aggregation-option"],
+                                        "choices": ["Manual", "None"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config delete": {
+                                    "name": "network manager security-admin-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool",
+                                        "aaz_default": false
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager security-admin-config list": {
+                                    "name": "network manager security-admin-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager security-admin-config show": {
+                                    "name": "network manager security-admin-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config update": {
+                                    "name": "network manager security-admin-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "apply_on_network_intent_policy",
+                                        "options": ["--apply-on", "--apply-on-network-intent-policy"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_address_space_aggregation_option",
+                                        "options": ["--aggregation", "--network-group-address-space-aggregation-option"],
+                                        "choices": ["Manual", "None"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config wait": {
+                                    "name": "network manager security-admin-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager security-admin-config rule-collection": {
+                                    "name": "network manager security-admin-config rule-collection",
+                                    "commands": {
+                                        "network manager security-admin-config rule-collection create": {
+                                            "name": "network manager security-admin-config rule-collection create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "resource_group_name",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "name"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "child_name_1"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "type": "string",
+                                                "required": true
+                                            }, {
+                                                "name": "applies_to_groups",
+                                                "options": ["--applies-to-groups"],
+                                                "required": true,
+                                                "nargs": "+"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection delete": {
+                                            "name": "network manager security-admin-config rule-collection delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "force",
+                                                "options": ["--force"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection list": {
+                                            "name": "network manager security-admin-config rule-collection list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection show": {
+                                            "name": "network manager security-admin-config rule-collection show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection update": {
+                                            "name": "network manager security-admin-config rule-collection update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "resource_group_name",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "name"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "child_name_1"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "type": "string",
+                                                "required": true
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to_groups",
+                                                "options": ["--applies-to-groups"],
+                                                "nargs": "+"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection wait": {
+                                            "name": "network manager security-admin-config rule-collection wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {
+                                        "network manager security-admin-config rule-collection rule": {
+                                            "name": "network manager security-admin-config rule-collection rule",
+                                            "commands": {
+                                                "network manager security-admin-config rule-collection rule create": {
+                                                    "name": "network manager security-admin-config rule-collection rule create",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "resource_group_name",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "name"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--configuration-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_1"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rule-collection-name"],
+                                                        "type": "string",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_2"
+                                                    }, {
+                                                        "name": "protocol",
+                                                        "options": ["--protocol"],
+                                                        "required": true,
+                                                        "choices": ["Ah", "Any", "Esp", "Icmp", "Tcp", "Udp"]
+                                                    }, {
+                                                        "name": "access",
+                                                        "options": ["--access"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "choices": ["Allow", "AlwaysAllow", "Deny"]
+                                                    }, {
+                                                        "name": "priority",
+                                                        "options": ["--priority"],
+                                                        "type": "int",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "direction",
+                                                        "options": ["--direction"],
+                                                        "required": true,
+                                                        "choices": ["Inbound", "Outbound"]
+                                                    }, {
+                                                        "name": "kind",
+                                                        "options": ["--kind"],
+                                                        "type": "string",
+                                                        "choices": ["Custom", "Default"],
+                                                        "default": "Custom"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "sources",
+                                                        "options": ["--sources"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destinations",
+                                                        "options": ["--destinations"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "source_port_ranges",
+                                                        "options": ["--source-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destination_port_ranges",
+                                                        "options": ["--dest-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "flag",
+                                                        "options": ["--flag"],
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule delete": {
+                                                    "name": "network manager security-admin-config rule-collection rule delete",
+                                                    "is_aaz": true,
+                                                    "supports_no_wait": true,
+                                                    "parameters": [{
+                                                        "name": "no_wait",
+                                                        "options": ["--no-wait"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "force",
+                                                        "options": ["--force"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "yes",
+                                                        "options": ["--yes", "-y"]
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule list": {
+                                                    "name": "network manager security-admin-config rule-collection rule list",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "pagination_token",
+                                                        "options": ["--next-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "pagination_limit",
+                                                        "options": ["--max-items"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "skip_token",
+                                                        "options": ["--skip-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "top",
+                                                        "options": ["--top"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule show": {
+                                                    "name": "network manager security-admin-config rule-collection rule show",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule update": {
+                                                    "name": "network manager security-admin-config rule-collection rule update",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "resource_group_name",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "name"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--configuration-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_1"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rule-collection-name"],
+                                                        "type": "string",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_2"
+                                                    }, {
+                                                        "name": "kind",
+                                                        "options": ["--kind"],
+                                                        "type": "string",
+                                                        "choices": ["Custom", "Default"]
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "protocol",
+                                                        "options": ["--protocol"],
+                                                        "choices": ["Ah", "Any", "Esp", "Icmp", "Tcp", "Udp"]
+                                                    }, {
+                                                        "name": "sources",
+                                                        "options": ["--sources"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destinations",
+                                                        "options": ["--destinations"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "source_port_ranges",
+                                                        "options": ["--source-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destination_port_ranges",
+                                                        "options": ["--dest-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "access",
+                                                        "options": ["--access"],
+                                                        "type": "string",
+                                                        "choices": ["Allow", "AlwaysAllow", "Deny"]
+                                                    }, {
+                                                        "name": "priority",
+                                                        "options": ["--priority"],
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "direction",
+                                                        "options": ["--direction"],
+                                                        "choices": ["Inbound", "Outbound"]
+                                                    }, {
+                                                        "name": "flag",
+                                                        "options": ["--flag"],
+                                                        "type": "string"
+                                                    }]
+                                                }
+                                            },
+                                            "sub_groups": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "network manager verifier-workspace": {
+                            "name": "network manager verifier-workspace",
+                            "commands": {
+                                "network manager verifier-workspace create": {
+                                    "name": "network manager verifier-workspace create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "location",
+                                        "options": ["--location", "-l"],
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace delete": {
+                                    "name": "network manager verifier-workspace delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager verifier-workspace list": {
+                                    "name": "network manager verifier-workspace list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip",
+                                        "options": ["--skip"],
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 0
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_key",
+                                        "options": ["--sort-key"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_value",
+                                        "options": ["--sort-value"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "default": 50,
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 50
+                                    }]
+                                },
+                                "network manager verifier-workspace show": {
+                                    "name": "network manager verifier-workspace show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace update": {
+                                    "name": "network manager verifier-workspace update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace wait": {
+                                    "name": "network manager verifier-workspace wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager verifier-workspace reachability-analysis-intent": {
+                                    "name": "network manager verifier-workspace reachability-analysis-intent",
+                                    "commands": {
+                                        "network manager verifier-workspace reachability-analysis-intent create": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "destination_resource_id",
+                                                "options": ["--dest-resource-id", "--destination-resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "ip_traffic",
+                                                "options": ["--ip-traffic"],
+                                                "required": true,
+                                                "nargs": "+",
+                                                "aaz_type": "AAZObjectArg",
+                                                "type": "Object"
+                                            }, {
+                                                "name": "source_resource_id",
+                                                "options": ["--source-resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent delete": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent list": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent show": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                },
+                                "network manager verifier-workspace reachability-analysis-run": {
+                                    "name": "network manager verifier-workspace reachability-analysis-run",
+                                    "commands": {
+                                        "network manager verifier-workspace reachability-analysis-run create": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "intent_id",
+                                                "options": ["--intent-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run delete": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run list": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run show": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run wait": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/azure-cli-diff-tool/tests/jsons/az_virtual-network-manager_meta_before.json
+++ b/azure-cli-diff-tool/tests/jsons/az_virtual-network-manager_meta_before.json
@@ -1,0 +1,4810 @@
+{
+    "module_name": "virtual-network-manager",
+    "name": "az",
+    "commands": {},
+    "sub_groups": {
+        "network": {
+            "name": "network",
+            "commands": {},
+            "sub_groups": {
+                "network manager": {
+                    "name": "network manager",
+                    "commands": {
+                        "network manager create": {
+                            "name": "network manager create",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group_name",
+                                "options": ["--resource-group"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "type": "string",
+                                "required": true,
+                                "id_part": "name"
+                            }, {
+                                "name": "location",
+                                "options": ["--location", "-l"],
+                                "type": "custom_type",
+                                "required": true,
+                                "has_completer": true
+                            }, {
+                                "name": "network_manager_scopes",
+                                "options": ["--network-manager-scopes"],
+                                "required": true,
+                                "nargs": "+"
+                            }, {
+                                "name": "network_manager_scope_accesses",
+                                "options": ["--scope-accesses"],
+                                "required": true,
+                                "nargs": "+"
+                            }, {
+                                "name": "id_",
+                                "options": ["--id"],
+                                "type": "string"
+                            }, {
+                                "name": "tags",
+                                "options": ["--tags"],
+                                "nargs": "*"
+                            }, {
+                                "name": "description",
+                                "options": ["--description"],
+                                "type": "string"
+                            }]
+                        },
+                        "network manager delete": {
+                            "name": "network manager delete",
+                            "is_aaz": true,
+                            "supports_no_wait": true,
+                            "parameters": [{
+                                "name": "no_wait",
+                                "options": ["--no-wait"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "force",
+                                "options": ["--force"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "yes",
+                                "options": ["--yes", "-y"]
+                            }]
+                        },
+                        "network manager list": {
+                            "name": "network manager list",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "pagination_token",
+                                "options": ["--next-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "pagination_limit",
+                                "options": ["--max-items"],
+                                "aaz_type": "int",
+                                "type": "int"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "top",
+                                "options": ["--top"],
+                                "aaz_type": "int",
+                                "type": "int"
+                            }]
+                        },
+                        "network manager list-active-connectivity-config": {
+                            "name": "network manager list-active-connectivity-config",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-active-security-admin-rule": {
+                            "name": "network manager list-active-security-admin-rule",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-deploy-status": {
+                            "name": "network manager list-deploy-status",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "deployment_types",
+                                "options": ["--deployment-types"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "regions",
+                                "options": ["--regions"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-effective-connectivity-config": {
+                            "name": "network manager list-effective-connectivity-config",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "virtual_network_name",
+                                "options": ["--virtual-network-name", "--vnet-name"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager list-effective-security-admin-rule": {
+                            "name": "network manager list-effective-security-admin-rule",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "virtual_network_name",
+                                "options": ["--virtual-network-name", "--vnet-name"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "skip_token",
+                                "options": ["--skip-token"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager post-commit": {
+                            "name": "network manager post-commit",
+                            "is_aaz": true,
+                            "supports_no_wait": true,
+                            "parameters": [{
+                                "name": "no_wait",
+                                "options": ["--no-wait"],
+                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                "nargs": "?",
+                                "aaz_type": "bool",
+                                "type": "bool"
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "commit_type",
+                                "options": ["--commit-type"],
+                                "required": true,
+                                "choices": ["Connectivity", "Routing", "SecurityAdmin", "SecurityUser"],
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "configuration_ids",
+                                "options": ["--configuration-ids"],
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }, {
+                                "name": "target_locations",
+                                "options": ["--target-locations"],
+                                "required": true,
+                                "nargs": "+",
+                                "aaz_type": "AAZListArg",
+                                "type": "List<String>"
+                            }]
+                        },
+                        "network manager show": {
+                            "name": "network manager show",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        },
+                        "network manager update": {
+                            "name": "network manager update",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "resource_group_name",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "type": "string",
+                                "required": true,
+                                "id_part": "name"
+                            }, {
+                                "name": "id_",
+                                "options": ["--id"],
+                                "type": "string"
+                            }, {
+                                "name": "location",
+                                "options": ["--location", "-l"],
+                                "type": "custom_type",
+                                "has_completer": true
+                            }, {
+                                "name": "tags",
+                                "options": ["--tags"],
+                                "nargs": "*"
+                            }, {
+                                "name": "description",
+                                "options": ["--description"],
+                                "type": "string"
+                            }, {
+                                "name": "network_manager_scopes",
+                                "options": ["--network-manager-scopes"],
+                                "nargs": "+"
+                            }, {
+                                "name": "network_manager_scope_accesses",
+                                "options": ["--scope-accesses"],
+                                "nargs": "+"
+                            }]
+                        },
+                        "network manager wait": {
+                            "name": "network manager wait",
+                            "is_aaz": true,
+                            "parameters": [{
+                                "name": "timeout",
+                                "options": ["--timeout"],
+                                "type": "int",
+                                "default": 3600
+                            }, {
+                                "name": "interval",
+                                "options": ["--interval"],
+                                "type": "int",
+                                "default": 30
+                            }, {
+                                "name": "deleted",
+                                "options": ["--deleted"]
+                            }, {
+                                "name": "created",
+                                "options": ["--created"]
+                            }, {
+                                "name": "updated",
+                                "options": ["--updated"]
+                            }, {
+                                "name": "exists",
+                                "options": ["--exists"]
+                            }, {
+                                "name": "custom",
+                                "options": ["--custom"]
+                            }, {
+                                "name": "network_manager_name",
+                                "options": ["--name", "--network-manager-name", "-n"],
+                                "required": true,
+                                "id_part": "name",
+                                "aaz_type": "string",
+                                "type": "string"
+                            }, {
+                                "name": "resource_group",
+                                "options": ["--resource-group", "-g"],
+                                "required": true,
+                                "id_part": "resource_group",
+                                "has_completer": true,
+                                "aaz_type": "string",
+                                "type": "string"
+                            }]
+                        }
+                    },
+                    "sub_groups": {
+                        "network manager connection": {
+                            "name": "network manager connection",
+                            "commands": {},
+                            "sub_groups": {
+                                "network manager connection management-group": {
+                                    "name": "network manager connection management-group",
+                                    "commands": {
+                                        "network manager connection management-group create": {
+                                            "name": "network manager connection management-group create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_id",
+                                                "options": ["--network-manager", "--network-manager-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection management-group delete": {
+                                            "name": "network manager connection management-group delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager connection management-group list": {
+                                            "name": "network manager connection management-group list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager connection management-group show": {
+                                            "name": "network manager connection management-group show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection management-group update": {
+                                            "name": "network manager connection management-group update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "management_group_id",
+                                                "options": ["--management-group-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                },
+                                "network manager connection subscription": {
+                                    "name": "network manager connection subscription",
+                                    "commands": {
+                                        "network manager connection subscription create": {
+                                            "name": "network manager connection subscription create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_id",
+                                                "options": ["--network-manager", "--network-manager-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection subscription delete": {
+                                            "name": "network manager connection subscription delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager connection subscription list": {
+                                            "name": "network manager connection subscription list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager connection subscription show": {
+                                            "name": "network manager connection subscription show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager connection subscription update": {
+                                            "name": "network manager connection subscription update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "connection_name",
+                                                "options": ["--connection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager connect-config": {
+                            "name": "network manager connect-config",
+                            "commands": {
+                                "network manager connect-config create": {
+                                    "name": "network manager connect-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "applies_to_groups",
+                                        "options": ["--applies-to-group", "--applies-to-groups"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "connectivity_topology",
+                                        "options": ["--connectivity-topology"],
+                                        "choices": ["HubAndSpoke", "Mesh"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "delete_existing_peering",
+                                        "options": ["--delete-existing-peering"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "hubs",
+                                        "options": ["--hub", "--hubs"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "is_global",
+                                        "options": ["--is-global"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config delete": {
+                                    "name": "network manager connect-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager connect-config list": {
+                                    "name": "network manager connect-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager connect-config show": {
+                                    "name": "network manager connect-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config update": {
+                                    "name": "network manager connect-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "applies_to_groups",
+                                        "options": ["--applies-to-group", "--applies-to-groups"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "connectivity_topology",
+                                        "options": ["--connectivity-topology"],
+                                        "choices": ["HubAndSpoke", "Mesh"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "delete_existing_peering",
+                                        "options": ["--delete-existing-peering"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "hubs",
+                                        "options": ["--hub", "--hubs"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<Object>"
+                                    }, {
+                                        "name": "is_global",
+                                        "options": ["--is-global"],
+                                        "choices": ["False", "True"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager connect-config wait": {
+                                    "name": "network manager connect-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {}
+                        },
+                        "network manager group": {
+                            "name": "network manager group",
+                            "commands": {
+                                "network manager group create": {
+                                    "name": "network manager group create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "if_match",
+                                        "options": ["--if-match"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group delete": {
+                                    "name": "network manager group delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager group list": {
+                                    "name": "network manager group list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager group show": {
+                                    "name": "network manager group show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group update": {
+                                    "name": "network manager group update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "if_match",
+                                        "options": ["--if-match"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager group wait": {
+                                    "name": "network manager group wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_group_name",
+                                        "options": ["--name", "--network-group-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager group static-member": {
+                                    "name": "network manager group static-member",
+                                    "commands": {
+                                        "network manager group static-member create": {
+                                            "name": "network manager group static-member create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_id",
+                                                "options": ["--resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager group static-member delete": {
+                                            "name": "network manager group static-member delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager group static-member list": {
+                                            "name": "network manager group static-member list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager group static-member show": {
+                                            "name": "network manager group static-member show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_group_name",
+                                                "options": ["--network-group", "--network-group-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--network-manager", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_member_name",
+                                                "options": ["--name", "--static-member-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager ipam-pool": {
+                            "name": "network manager ipam-pool",
+                            "commands": {
+                                "network manager ipam-pool create": {
+                                    "name": "network manager ipam-pool create",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "location",
+                                        "options": ["--location", "-l"],
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "address_prefixes",
+                                        "options": ["--address-prefixes"],
+                                        "required": true,
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "display_name",
+                                        "options": ["--display-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "parent_pool_name",
+                                        "options": ["--parent-pool-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool delete": {
+                                    "name": "network manager ipam-pool delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager ipam-pool get-pool-usage": {
+                                    "name": "network manager ipam-pool get-pool-usage",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool list": {
+                                    "name": "network manager ipam-pool list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip",
+                                        "options": ["--skip"],
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 0
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_key",
+                                        "options": ["--sort-key"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_value",
+                                        "options": ["--sort-value"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "default": 50,
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 50
+                                    }]
+                                },
+                                "network manager ipam-pool list-associated-resource": {
+                                    "name": "network manager ipam-pool list-associated-resource",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool show": {
+                                    "name": "network manager ipam-pool show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool update": {
+                                    "name": "network manager ipam-pool update",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "display_name",
+                                        "options": ["--display-name"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager ipam-pool wait": {
+                                    "name": "network manager ipam-pool wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pool_name",
+                                        "options": ["--name", "--pool-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager ipam-pool static-cidr": {
+                                    "name": "network manager ipam-pool static-cidr",
+                                    "commands": {
+                                        "network manager ipam-pool static-cidr create": {
+                                            "name": "network manager ipam-pool static-cidr create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "address_prefixes",
+                                                "options": ["--address-prefixes"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<String>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "number_of_ip_addresses_to_allocate",
+                                                "options": ["--allocate", "--number-of-ip-addresses-to-allocate", "-a"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr delete": {
+                                            "name": "network manager ipam-pool static-cidr delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr list": {
+                                            "name": "network manager ipam-pool static-cidr list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr show": {
+                                            "name": "network manager ipam-pool static-cidr show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager ipam-pool static-cidr wait": {
+                                            "name": "network manager ipam-pool static-cidr wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pool_name",
+                                                "options": ["--pool-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "static_cidr_name",
+                                                "options": ["--name", "--static-cidr-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        },
+                        "network manager routing-config": {
+                            "name": "network manager routing-config",
+                            "commands": {
+                                "network manager routing-config create": {
+                                    "name": "network manager routing-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config delete": {
+                                    "name": "network manager routing-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager routing-config list": {
+                                    "name": "network manager routing-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager routing-config show": {
+                                    "name": "network manager routing-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config update": {
+                                    "name": "network manager routing-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager routing-config wait": {
+                                    "name": "network manager routing-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "config_name",
+                                        "options": ["--config-name", "--name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "manager_name",
+                                        "options": ["--manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager routing-config rule-collection": {
+                                    "name": "network manager routing-config rule-collection",
+                                    "commands": {
+                                        "network manager routing-config rule-collection create": {
+                                            "name": "network manager routing-config rule-collection create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to",
+                                                "options": ["--applies-to"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<Object>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "disable_bgp_route",
+                                                "options": ["--disable-bgp-route"],
+                                                "choices": ["False", "True"],
+                                                "default": "true",
+                                                "aaz_type": "string",
+                                                "type": "string",
+                                                "aaz_default": "true"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection delete": {
+                                            "name": "network manager routing-config rule-collection delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "force",
+                                                "options": ["--force"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection list": {
+                                            "name": "network manager routing-config rule-collection list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection show": {
+                                            "name": "network manager routing-config rule-collection show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection update": {
+                                            "name": "network manager routing-config rule-collection update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "generic_update_add",
+                                                "options": ["--add"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateAddArg"
+                                            }, {
+                                                "name": "generic_update_set",
+                                                "options": ["--set"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateSetArg"
+                                            }, {
+                                                "name": "generic_update_remove",
+                                                "options": ["--remove"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZGenericUpdateRemoveArg"
+                                            }, {
+                                                "name": "generic_update_force_string",
+                                                "options": ["--force-string"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to",
+                                                "options": ["--applies-to"],
+                                                "nargs": "+",
+                                                "aaz_type": "AAZListArg",
+                                                "type": "List<Object>"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "disable_bgp_route",
+                                                "options": ["--disable-bgp-route"],
+                                                "choices": ["False", "True"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager routing-config rule-collection wait": {
+                                            "name": "network manager routing-config rule-collection wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "config_name",
+                                                "options": ["--config-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "manager_name",
+                                                "options": ["--manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "collection_name",
+                                                "options": ["--collection-name", "--name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {
+                                        "network manager routing-config rule-collection rule": {
+                                            "name": "network manager routing-config rule-collection rule",
+                                            "commands": {
+                                                "network manager routing-config rule-collection rule create": {
+                                                    "name": "network manager routing-config rule-collection rule create",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "destination",
+                                                        "options": ["--destination"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }, {
+                                                        "name": "next_hop",
+                                                        "options": ["--next-hop"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule delete": {
+                                                    "name": "network manager routing-config rule-collection rule delete",
+                                                    "is_aaz": true,
+                                                    "supports_no_wait": true,
+                                                    "parameters": [{
+                                                        "name": "no_wait",
+                                                        "options": ["--no-wait"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "force",
+                                                        "options": ["--force"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "yes",
+                                                        "options": ["--yes", "-y"]
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule list": {
+                                                    "name": "network manager routing-config rule-collection rule list",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "pagination_token",
+                                                        "options": ["--next-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "pagination_limit",
+                                                        "options": ["--max-items"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "skip_token",
+                                                        "options": ["--skip-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "top",
+                                                        "options": ["--top"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule show": {
+                                                    "name": "network manager routing-config rule-collection rule show",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule update": {
+                                                    "name": "network manager routing-config rule-collection rule update",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "generic_update_add",
+                                                        "options": ["--add"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                                    }, {
+                                                        "name": "generic_update_set",
+                                                        "options": ["--set"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                                    }, {
+                                                        "name": "generic_update_remove",
+                                                        "options": ["--remove"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                                    }, {
+                                                        "name": "generic_update_force_string",
+                                                        "options": ["--force-string"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "destination",
+                                                        "options": ["--destination"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }, {
+                                                        "name": "next_hop",
+                                                        "options": ["--next-hop"],
+                                                        "nargs": "+",
+                                                        "aaz_type": "AAZObjectArg",
+                                                        "type": "Object"
+                                                    }]
+                                                },
+                                                "network manager routing-config rule-collection rule wait": {
+                                                    "name": "network manager routing-config rule-collection rule wait",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "timeout",
+                                                        "options": ["--timeout"],
+                                                        "type": "int",
+                                                        "default": 3600
+                                                    }, {
+                                                        "name": "interval",
+                                                        "options": ["--interval"],
+                                                        "type": "int",
+                                                        "default": 30
+                                                    }, {
+                                                        "name": "deleted",
+                                                        "options": ["--deleted"]
+                                                    }, {
+                                                        "name": "created",
+                                                        "options": ["--created"]
+                                                    }, {
+                                                        "name": "updated",
+                                                        "options": ["--updated"]
+                                                    }, {
+                                                        "name": "exists",
+                                                        "options": ["--exists"]
+                                                    }, {
+                                                        "name": "custom",
+                                                        "options": ["--custom"]
+                                                    }, {
+                                                        "name": "config_name",
+                                                        "options": ["--config-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "manager_name",
+                                                        "options": ["--manager-name"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "collection_name",
+                                                        "options": ["--collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--name", "--rule-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                }
+                                            },
+                                            "sub_groups": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "network manager scope-connection": {
+                            "name": "network manager scope-connection",
+                            "commands": {
+                                "network manager scope-connection create": {
+                                    "name": "network manager scope-connection create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_id",
+                                        "options": ["--resource-id"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tenant_id",
+                                        "options": ["--tenant-id"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager scope-connection delete": {
+                                    "name": "network manager scope-connection delete",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager scope-connection list": {
+                                    "name": "network manager scope-connection list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager scope-connection show": {
+                                    "name": "network manager scope-connection show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager scope-connection update": {
+                                    "name": "network manager scope-connection update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--network-manager", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "scope_connection_name",
+                                        "options": ["--connection-name", "--name", "--scope-connection-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {}
+                        },
+                        "network manager security-admin-config": {
+                            "name": "network manager security-admin-config",
+                            "commands": {
+                                "network manager security-admin-config create": {
+                                    "name": "network manager security-admin-config create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "apply_on_network_intent_policy",
+                                        "options": ["--apply-on", "--apply-on-network-intent-policy"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_address_space_aggregation_option",
+                                        "options": ["--aggregation", "--network-group-address-space-aggregation-option"],
+                                        "choices": ["Manual", "None"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config delete": {
+                                    "name": "network manager security-admin-config delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "force",
+                                        "options": ["--force"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool",
+                                        "aaz_default": false
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager security-admin-config list": {
+                                    "name": "network manager security-admin-config list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }]
+                                },
+                                "network manager security-admin-config show": {
+                                    "name": "network manager security-admin-config show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config update": {
+                                    "name": "network manager security-admin-config update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "apply_on_network_intent_policy",
+                                        "options": ["--apply-on", "--apply-on-network-intent-policy"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZListArg",
+                                        "type": "List<String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_group_address_space_aggregation_option",
+                                        "options": ["--aggregation", "--network-group-address-space-aggregation-option"],
+                                        "choices": ["Manual", "None"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager security-admin-config wait": {
+                                    "name": "network manager security-admin-config wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "configuration_name",
+                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--name", "--network-manager-name", "-n"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager security-admin-config rule-collection": {
+                                    "name": "network manager security-admin-config rule-collection",
+                                    "commands": {
+                                        "network manager security-admin-config rule-collection create": {
+                                            "name": "network manager security-admin-config rule-collection create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "resource_group_name",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "name"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "child_name_1"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "type": "string",
+                                                "required": true
+                                            }, {
+                                                "name": "applies_to_groups",
+                                                "options": ["--applies-to-groups"],
+                                                "required": true,
+                                                "nargs": "+"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection delete": {
+                                            "name": "network manager security-admin-config rule-collection delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "force",
+                                                "options": ["--force"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection list": {
+                                            "name": "network manager security-admin-config rule-collection list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection show": {
+                                            "name": "network manager security-admin-config rule-collection show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection update": {
+                                            "name": "network manager security-admin-config rule-collection update",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "resource_group_name",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "name"
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "type": "string",
+                                                "required": true,
+                                                "id_part": "child_name_1"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "type": "string",
+                                                "required": true
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "type": "string"
+                                            }, {
+                                                "name": "applies_to_groups",
+                                                "options": ["--applies-to-groups"],
+                                                "nargs": "+"
+                                            }]
+                                        },
+                                        "network manager security-admin-config rule-collection wait": {
+                                            "name": "network manager security-admin-config rule-collection wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "configuration_name",
+                                                "options": ["--configuration-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--name", "--network-manager-name", "-n"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "rule_collection_name",
+                                                "options": ["--rule-collection-name"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {
+                                        "network manager security-admin-config rule-collection rule": {
+                                            "name": "network manager security-admin-config rule-collection rule",
+                                            "commands": {
+                                                "network manager security-admin-config rule-collection rule create": {
+                                                    "name": "network manager security-admin-config rule-collection rule create",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "resource_group_name",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "name"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--configuration-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_1"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rule-collection-name"],
+                                                        "type": "string",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_2"
+                                                    }, {
+                                                        "name": "protocol",
+                                                        "options": ["--protocol"],
+                                                        "required": true,
+                                                        "choices": ["Ah", "Any", "Esp", "Icmp", "Tcp", "Udp"]
+                                                    }, {
+                                                        "name": "access",
+                                                        "options": ["--access"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "choices": ["Allow", "AlwaysAllow", "Deny"]
+                                                    }, {
+                                                        "name": "priority",
+                                                        "options": ["--priority"],
+                                                        "type": "int",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "direction",
+                                                        "options": ["--direction"],
+                                                        "required": true,
+                                                        "choices": ["Inbound", "Outbound"]
+                                                    }, {
+                                                        "name": "kind",
+                                                        "options": ["--kind"],
+                                                        "type": "string",
+                                                        "choices": ["Custom", "Default"],
+                                                        "default": "Custom"
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "sources",
+                                                        "options": ["--sources"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destinations",
+                                                        "options": ["--destinations"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "source_port_ranges",
+                                                        "options": ["--source-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destination_port_ranges",
+                                                        "options": ["--dest-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "flag",
+                                                        "options": ["--flag"],
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule delete": {
+                                                    "name": "network manager security-admin-config rule-collection rule delete",
+                                                    "is_aaz": true,
+                                                    "supports_no_wait": true,
+                                                    "parameters": [{
+                                                        "name": "no_wait",
+                                                        "options": ["--no-wait"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "force",
+                                                        "options": ["--force"],
+                                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                        "nargs": "?",
+                                                        "aaz_type": "bool",
+                                                        "type": "bool"
+                                                    }, {
+                                                        "name": "yes",
+                                                        "options": ["--yes", "-y"]
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule list": {
+                                                    "name": "network manager security-admin-config rule-collection rule list",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "pagination_token",
+                                                        "options": ["--next-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "pagination_limit",
+                                                        "options": ["--max-items"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "skip_token",
+                                                        "options": ["--skip-token"],
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "top",
+                                                        "options": ["--top"],
+                                                        "aaz_type": "int",
+                                                        "type": "int"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule show": {
+                                                    "name": "network manager security-admin-config rule-collection rule show",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "configuration_name",
+                                                        "options": ["--config", "--config-name", "--configuration-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_1",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "required": true,
+                                                        "id_part": "name",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "resource_group",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true,
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rc", "--rule-collection-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_2",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "required": true,
+                                                        "id_part": "child_name_3",
+                                                        "aaz_type": "string",
+                                                        "type": "string"
+                                                    }]
+                                                },
+                                                "network manager security-admin-config rule-collection rule update": {
+                                                    "name": "network manager security-admin-config rule-collection rule update",
+                                                    "is_aaz": true,
+                                                    "parameters": [{
+                                                        "name": "resource_group_name",
+                                                        "options": ["--resource-group", "-g"],
+                                                        "required": true,
+                                                        "id_part": "resource_group",
+                                                        "has_completer": true
+                                                    }, {
+                                                        "name": "network_manager_name",
+                                                        "options": ["--name", "--network-manager-name", "-n"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "name"
+                                                    }, {
+                                                        "name": "configuration_name",
+                                                        "options": ["--configuration-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_1"
+                                                    }, {
+                                                        "name": "rule_collection_name",
+                                                        "options": ["--rule-collection-name"],
+                                                        "type": "string",
+                                                        "required": true
+                                                    }, {
+                                                        "name": "rule_name",
+                                                        "options": ["--rule-name"],
+                                                        "type": "string",
+                                                        "required": true,
+                                                        "id_part": "child_name_2"
+                                                    }, {
+                                                        "name": "kind",
+                                                        "options": ["--kind"],
+                                                        "type": "string",
+                                                        "choices": ["Custom", "Default"]
+                                                    }, {
+                                                        "name": "description",
+                                                        "options": ["--description"],
+                                                        "type": "string"
+                                                    }, {
+                                                        "name": "protocol",
+                                                        "options": ["--protocol"],
+                                                        "choices": ["Ah", "Any", "Esp", "Icmp", "Tcp", "Udp"]
+                                                    }, {
+                                                        "name": "sources",
+                                                        "options": ["--sources"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destinations",
+                                                        "options": ["--destinations"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "source_port_ranges",
+                                                        "options": ["--source-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "destination_port_ranges",
+                                                        "options": ["--dest-port-ranges"],
+                                                        "nargs": "+"
+                                                    }, {
+                                                        "name": "access",
+                                                        "options": ["--access"],
+                                                        "type": "string",
+                                                        "choices": ["Allow", "AlwaysAllow", "Deny"]
+                                                    }, {
+                                                        "name": "priority",
+                                                        "options": ["--priority"],
+                                                        "type": "int"
+                                                    }, {
+                                                        "name": "direction",
+                                                        "options": ["--direction"],
+                                                        "choices": ["Inbound", "Outbound"]
+                                                    }, {
+                                                        "name": "flag",
+                                                        "options": ["--flag"],
+                                                        "type": "string"
+                                                    }]
+                                                }
+                                            },
+                                            "sub_groups": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "network manager verifier-workspace": {
+                            "name": "network manager verifier-workspace",
+                            "commands": {
+                                "network manager verifier-workspace create": {
+                                    "name": "network manager verifier-workspace create",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "location",
+                                        "options": ["--location", "-l"],
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace delete": {
+                                    "name": "network manager verifier-workspace delete",
+                                    "is_aaz": true,
+                                    "supports_no_wait": true,
+                                    "parameters": [{
+                                        "name": "no_wait",
+                                        "options": ["--no-wait"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "yes",
+                                        "options": ["--yes", "-y"]
+                                    }]
+                                },
+                                "network manager verifier-workspace list": {
+                                    "name": "network manager verifier-workspace list",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "pagination_token",
+                                        "options": ["--next-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "pagination_limit",
+                                        "options": ["--max-items"],
+                                        "aaz_type": "int",
+                                        "type": "int"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "skip",
+                                        "options": ["--skip"],
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 0
+                                    }, {
+                                        "name": "skip_token",
+                                        "options": ["--skip-token"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_key",
+                                        "options": ["--sort-key"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "sort_value",
+                                        "options": ["--sort-value"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "top",
+                                        "options": ["--top"],
+                                        "default": 50,
+                                        "aaz_type": "int",
+                                        "type": "int",
+                                        "aaz_default": 50
+                                    }]
+                                },
+                                "network manager verifier-workspace show": {
+                                    "name": "network manager verifier-workspace show",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace update": {
+                                    "name": "network manager verifier-workspace update",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "generic_update_add",
+                                        "options": ["--add"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateAddArg"
+                                    }, {
+                                        "name": "generic_update_set",
+                                        "options": ["--set"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateSetArg"
+                                    }, {
+                                        "name": "generic_update_remove",
+                                        "options": ["--remove"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZGenericUpdateRemoveArg"
+                                    }, {
+                                        "name": "generic_update_force_string",
+                                        "options": ["--force-string"],
+                                        "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                        "nargs": "?",
+                                        "aaz_type": "bool",
+                                        "type": "bool"
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "tags",
+                                        "options": ["--tags"],
+                                        "nargs": "+",
+                                        "aaz_type": "AAZDictArg",
+                                        "type": "Dict<String,String>"
+                                    }, {
+                                        "name": "description",
+                                        "options": ["--description"],
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                },
+                                "network manager verifier-workspace wait": {
+                                    "name": "network manager verifier-workspace wait",
+                                    "is_aaz": true,
+                                    "parameters": [{
+                                        "name": "timeout",
+                                        "options": ["--timeout"],
+                                        "type": "int",
+                                        "default": 3600
+                                    }, {
+                                        "name": "interval",
+                                        "options": ["--interval"],
+                                        "type": "int",
+                                        "default": 30
+                                    }, {
+                                        "name": "deleted",
+                                        "options": ["--deleted"]
+                                    }, {
+                                        "name": "created",
+                                        "options": ["--created"]
+                                    }, {
+                                        "name": "updated",
+                                        "options": ["--updated"]
+                                    }, {
+                                        "name": "exists",
+                                        "options": ["--exists"]
+                                    }, {
+                                        "name": "custom",
+                                        "options": ["--custom"]
+                                    }, {
+                                        "name": "network_manager_name",
+                                        "options": ["--manager-name", "--network-manager-name"],
+                                        "required": true,
+                                        "id_part": "name",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "resource_group",
+                                        "options": ["--resource-group", "-g"],
+                                        "required": true,
+                                        "id_part": "resource_group",
+                                        "has_completer": true,
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }, {
+                                        "name": "workspace_name",
+                                        "options": ["--name", "--workspace-name", "-n"],
+                                        "required": true,
+                                        "id_part": "child_name_1",
+                                        "aaz_type": "string",
+                                        "type": "string"
+                                    }]
+                                }
+                            },
+                            "sub_groups": {
+                                "network manager verifier-workspace reachability-analysis-intent": {
+                                    "name": "network manager verifier-workspace reachability-analysis-intent",
+                                    "commands": {
+                                        "network manager verifier-workspace reachability-analysis-intent create": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "destination_resource_id",
+                                                "options": ["--dest-resource-id", "--destination-resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "ip_traffic",
+                                                "options": ["--ip-traffic"],
+                                                "required": true,
+                                                "nargs": "+",
+                                                "aaz_type": "AAZObjectArg",
+                                                "type": "Object"
+                                            }, {
+                                                "name": "source_resource_id",
+                                                "options": ["--source-resource-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent delete": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent delete",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent list": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-intent show": {
+                                            "name": "network manager verifier-workspace reachability-analysis-intent show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_intent_name",
+                                                "options": ["--name", "--reachability-analysis-intent-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                },
+                                "network manager verifier-workspace reachability-analysis-run": {
+                                    "name": "network manager verifier-workspace reachability-analysis-run",
+                                    "commands": {
+                                        "network manager verifier-workspace reachability-analysis-run create": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run create",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "description",
+                                                "options": ["--description"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "intent_id",
+                                                "options": ["--intent-id"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run delete": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run delete",
+                                            "is_aaz": true,
+                                            "supports_no_wait": true,
+                                            "parameters": [{
+                                                "name": "no_wait",
+                                                "options": ["--no-wait"],
+                                                "choices": ["0", "1", "f", "false", "n", "no", "t", "true", "y", "yes"],
+                                                "nargs": "?",
+                                                "aaz_type": "bool",
+                                                "type": "bool"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "yes",
+                                                "options": ["--yes", "-y"]
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run list": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run list",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "pagination_token",
+                                                "options": ["--next-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "pagination_limit",
+                                                "options": ["--max-items"],
+                                                "aaz_type": "int",
+                                                "type": "int"
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "skip",
+                                                "options": ["--skip"],
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 0
+                                            }, {
+                                                "name": "skip_token",
+                                                "options": ["--skip-token"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_key",
+                                                "options": ["--sort-key"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "sort_value",
+                                                "options": ["--sort-value"],
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "top",
+                                                "options": ["--top"],
+                                                "default": 50,
+                                                "aaz_type": "int",
+                                                "type": "int",
+                                                "aaz_default": 50
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run show": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run show",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        },
+                                        "network manager verifier-workspace reachability-analysis-run wait": {
+                                            "name": "network manager verifier-workspace reachability-analysis-run wait",
+                                            "is_aaz": true,
+                                            "parameters": [{
+                                                "name": "timeout",
+                                                "options": ["--timeout"],
+                                                "type": "int",
+                                                "default": 3600
+                                            }, {
+                                                "name": "interval",
+                                                "options": ["--interval"],
+                                                "type": "int",
+                                                "default": 30
+                                            }, {
+                                                "name": "deleted",
+                                                "options": ["--deleted"]
+                                            }, {
+                                                "name": "created",
+                                                "options": ["--created"]
+                                            }, {
+                                                "name": "updated",
+                                                "options": ["--updated"]
+                                            }, {
+                                                "name": "exists",
+                                                "options": ["--exists"]
+                                            }, {
+                                                "name": "custom",
+                                                "options": ["--custom"]
+                                            }, {
+                                                "name": "network_manager_name",
+                                                "options": ["--manager-name", "--network-manager-name"],
+                                                "required": true,
+                                                "id_part": "name",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "reachability_analysis_run_name",
+                                                "options": ["--name", "--reachability-analysis-run-name", "-n"],
+                                                "required": true,
+                                                "id_part": "child_name_2",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "resource_group",
+                                                "options": ["--resource-group", "-g"],
+                                                "required": true,
+                                                "id_part": "resource_group",
+                                                "has_completer": true,
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }, {
+                                                "name": "workspace_name",
+                                                "options": ["--workspace-name"],
+                                                "required": true,
+                                                "id_part": "child_name_1",
+                                                "aaz_type": "string",
+                                                "type": "string"
+                                            }]
+                                        }
+                                    },
+                                    "sub_groups": {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/azure-cli-diff-tool/tests/test_break_change.py
+++ b/azure-cli-diff-tool/tests/test_break_change.py
@@ -183,6 +183,24 @@ class CLIDiffToolTestCase(unittest.TestCase):
             print(mes)
             self.assertTrue(found, "target message not found")
 
+    def test_diff_meta_with_different_mod_name(self):
+        if not os.path.exists("./jsons/az_virtual-network-manager_meta_before.json") \
+                or not os.path.exists("./jsons/az_network-manager_meta_after.json"):
+            raise ValueError("Meta file not found, please check testing package")
+        result = meta_diff(base_meta_file="./jsons/az_virtual-network-manager_meta_before.json",
+                           diff_meta_file="./jsons/az_network-manager_meta_after.json",
+                           output_type="text")
+        target_message = [
+            "updated property `name` from `network_manager_scopes` to `module_name`",
+        ]
+        for mes in target_message:
+            found = False
+            for line in result:
+                if line.find(mes) > -1:
+                    found = True
+                    break
+            self.assertTrue(found, "target message not found")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/azure-cli-diff-tool/tests/test_break_change.py
+++ b/azure-cli-diff-tool/tests/test_break_change.py
@@ -10,6 +10,7 @@ import os
 from azure_cli_diff_tool import meta_diff
 from azure_cli_diff_tool.utils import get_command_tree, extract_cmd_name, extract_cmd_property, extract_para_info, \
     extract_subgroup_name, extract_subgroup_deprecate_property, expand_deprecate_obj, extract_subgroup_property
+TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
 
 class CLIDiffToolTestCase(unittest.TestCase):
@@ -65,12 +66,15 @@ class CLIDiffToolTestCase(unittest.TestCase):
         self.assertEqual(subgroup_prop, "deprecate_info_hide", "sub group prop extract failed")
 
     def test_diff_meta(self):
-        if not os.path.exists("./jsons/az_monitor_meta_before.json") \
-                or not os.path.exists("./jsons/az_monitor_meta_after.json"):
-            return
-        result = meta_diff(base_meta_file="./jsons/az_monitor_meta_before.json",
-                           diff_meta_file="./jsons/az_monitor_meta_after.json",
+        base_meta_file = os.path.join(TEST_DIR, "jsons", "az_monitor_meta_before.json")
+        diff_meta_file = os.path.join(TEST_DIR, "jsons", "az_monitor_meta_after.json")
+        if not os.path.exists(base_meta_file) or not os.path.exists(diff_meta_file):
+            raise ValueError("Meta file not found, please check testing package")
+
+        result = meta_diff(base_meta_file=base_meta_file,
+                           diff_meta_file=diff_meta_file,
                            output_type="text")
+
         target_message = [
             "please confirm cmd `monitor private-link-scope scoped-resource show` removed",
             "sub group `monitor private-link-scope private-endpoint-connection cust` removed",
@@ -97,20 +101,22 @@ class CLIDiffToolTestCase(unittest.TestCase):
             self.assertTrue(ignored, "ignored message found")
 
     def test_diff_meta_whitelist(self):
-        if not os.path.exists("./jsons/az_ams_meta_before.json") \
-                or not os.path.exists("./jsons/az_ams_meta_after.json"):
-            return
-        result = meta_diff(base_meta_file="./jsons/az_ams_meta_before.json",
-                           diff_meta_file="./jsons/az_ams_meta_after.json",
+        base_meta_file = os.path.join(TEST_DIR, "jsons", "az_ams_meta_before.json")
+        diff_meta_file = os.path.join(TEST_DIR, "jsons", "az_ams_meta_after.json")
+        if not os.path.exists(base_meta_file) or not os.path.exists(diff_meta_file):
+            raise ValueError("Meta file not found, please check testing package")
+        result = meta_diff(base_meta_file=base_meta_file,
+                           diff_meta_file=diff_meta_file,
                            output_type="text")
         self.assertEqual(result, [], "returned change isn't empty")
 
     def test_dynamic_diff_meta_whitelist(self):
-        if not os.path.exists("./jsons/az_mysql_meta_before.json") \
-                or not os.path.exists("./jsons/az_mysql_meta_after.json"):
-            return
-        result = meta_diff(base_meta_file="./jsons/az_mysql_meta_before.json",
-                           diff_meta_file="./jsons/az_mysql_meta_after.json",
+        base_meta_file = os.path.join(TEST_DIR, "jsons", "az_mysql_meta_before.json")
+        diff_meta_file = os.path.join(TEST_DIR, "jsons", "az_mysql_meta_after.json")
+        if not os.path.exists(base_meta_file) or not os.path.exists(diff_meta_file):
+            raise ValueError("Meta file not found, please check testing package")
+        result = meta_diff(base_meta_file=base_meta_file,
+                           diff_meta_file=diff_meta_file,
                            output_type="text")
         self.assertEqual(result, [], "returned change isn't empty")
 
@@ -158,11 +164,12 @@ class CLIDiffToolTestCase(unittest.TestCase):
         self.assertEqual(example_obj["sub_groups"]["acr"]["commands"]["acr helm list"]["parameters"][0]["deprecate_info_redirect"], "resource_group_name2", "deprecate info expand not working properly")
 
     def test_diff_meta_for_deprecate_info(self):
-        if not os.path.exists("./jsons/az_acr_meta_before.json") or not os.path.exists("./jsons/az_acr_meta_after.json"):
-            return
-        result = meta_diff(base_meta_file="./jsons/az_acr_meta_before.json",
-                           diff_meta_file="./jsons/az_acr_meta_after.json",
-                           output_type="text")
+        base_meta_file = os.path.join(TEST_DIR, "jsons", "az_acr_meta_before.json")
+        diff_meta_file = os.path.join(TEST_DIR, "jsons", "az_acr_meta_after.json")
+        if not os.path.exists(base_meta_file) or not os.path.exists(diff_meta_file):
+            raise ValueError("Meta file not found, please check testing package")
+
+        result = meta_diff(base_meta_file=base_meta_file, diff_meta_file=diff_meta_file, output_type="text")
         target_message = [
             "sub group `acr` added property `deprecate_info_hide` | diff_level: 2",
             "sub group `acr` updated property `deprecate_info_redirect` from `acr2` to `acr3` | diff_level: 1",
@@ -184,12 +191,11 @@ class CLIDiffToolTestCase(unittest.TestCase):
             self.assertTrue(found, "target message not found")
 
     def test_diff_meta_with_different_mod_name(self):
-        if not os.path.exists("./jsons/az_virtual-network-manager_meta_before.json") \
-                or not os.path.exists("./jsons/az_network-manager_meta_after.json"):
+        base_meta_file = os.path.join(TEST_DIR, "jsons", "az_virtual-network-manager_meta_before.json")
+        diff_meta_file = os.path.join(TEST_DIR, "jsons", "az_network-manager_meta_after.json")
+        if not os.path.exists(base_meta_file) or not os.path.exists(diff_meta_file):
             raise ValueError("Meta file not found, please check testing package")
-        result = meta_diff(base_meta_file="./jsons/az_virtual-network-manager_meta_before.json",
-                           diff_meta_file="./jsons/az_network-manager_meta_after.json",
-                           output_type="text")
+        result = meta_diff(base_meta_file=base_meta_file, diff_meta_file=diff_meta_file, output_type="text")
         target_message = [
             "updated property `name` from `network_manager_scopes` to `module_name`",
         ]


### PR DESCRIPTION
To enable meta diff from extension module installed from `whl`, the base meta is generated from last released `whl` package, and the diff meta is generated from current working extension directory. Therefore, it might be different in `module_name`, like `network-manager` and its package `virtual-network-manager`. 

We enabled the meta dict diff and exclude `module_name` comparison in this pr.

This pr is a preliminary task for solving following issues:

https://github.com/Azure/azure-cli-dev-tools/issues/504
https://github.com/Azure/azure-cli-dev-tools/issues/472