### PR TITLE
Bump pylint constraint to >=4,<5 for Python 3.14 and style compatibility

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,9 +8,11 @@ Release History
 
 0.2.9
 +++++
++++++
 * `azdev latest-index`: Add `generate` and `verify` commands to manage Azure CLI packaged latest indices (`commandIndex.latest.json`, `helpIndex.latest.json`) with CI-friendly verify exit behavior.
 
 0.2.8
+++++
 ++++++
 * Pin pip to 25.2 as pip 25.3 remove support for the legacy setup.py develop editable method in setuptools editable installs; setuptools >= 64 is now required. (#11457)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,15 +5,14 @@ Release History
 0.2.10
 ++++++
 * Add support for Python 3.14 and drop support for Python 3.9
+* Bump pylint constraint to >=4,<5 for Python 3.14 and style compatibility
 
 0.2.9
-+++++
 +++++
 * `azdev latest-index`: Add `generate` and `verify` commands to manage Azure CLI packaged latest indices (`commandIndex.latest.json`, `helpIndex.latest.json`) with CI-friendly verify exit behavior.
 
 0.2.8
-++++
-++++++
++++++
 * Pin pip to 25.2 as pip 25.3 remove support for the legacy setup.py develop editable method in setuptools editable installs; setuptools >= 64 is now required. (#11457)
 
 0.2.7

--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -88,6 +88,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -147,6 +149,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -181,6 +185,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -215,6 +221,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -249,6 +257,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -282,6 +292,8 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
+      Python314:
+        python.version: '3.14'
   steps:
     - task: DownloadPipelineArtifact@1
       displayName: 'Download Build'

--- a/azure-pipelines-cli.yml
+++ b/azure-pipelines-cli.yml
@@ -88,8 +88,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -149,8 +147,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -185,8 +181,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -221,8 +215,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -257,8 +249,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Build'
@@ -292,8 +282,6 @@ jobs:
         python.version: '3.12'
       Python313:
         python.version: '3.13'
-      Python314:
-        python.version: '3.14'
   steps:
     - task: DownloadPipelineArtifact@1
       displayName: 'Download Build'

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'gitpython',
         'jinja2',
         'knack',
-        'pylint<4',
+        'pylint>=4,<5',
         'pytest-xdist',  # depends on pytest-forked
         'pytest-forked',
         'pytest>=5.0.0',


### PR DESCRIPTION
This PR updates azdev tooling compatibility and CI coverage for Python 3.14.

## Changes in this PR
- Bump pylint dependency constraint in `setup.py` from `<4` to `>=4,<5`.
- Fix `HISTORY.rst` formatting and add a changelog note for the pylint constraint update.

## Out of scope
- No Azure CLI command-module code fixes are included in this repo/PR.
- Pylint 4 code-fix changes are tracked in the separate `azure-cli` [PR](https://github.com/Azure/azure-cli/pull/33347).

## Coordination
- Merge the `azure-cli` code-fix [PR](https://github.com/Azure/azure-cli/pull/33347) first.
- Then merge this `azure-cli-dev-tools` PR to raise the pylint constraint.