### PR TITLE
 Fix editable extension install losing egg-info under --no-build-isolation

### DIFF
--- a/azdev/operations/code_gen.py
+++ b/azdev/operations/code_gen.py
@@ -15,6 +15,7 @@ from knack.util import CLIError
 from azdev.utilities import (
     pip_cmd, display, heading, COMMAND_MODULE_PREFIX, EXTENSION_PREFIX, get_cli_repo_path, get_ext_repo_paths,
     find_files, quote_arg)
+from azdev.operations.extensions import _ensure_egg_info
 
 logger = get_logger(__name__)
 
@@ -305,3 +306,4 @@ def _create_package(prefix, repo_path, is_ext, name='test', display_name=None, d
         )
         if result.error:
             raise result.error  # pylint: disable=raising-bad-type
+        _ensure_egg_info(new_package_path)

--- a/azdev/operations/extensions/__init__.py
+++ b/azdev/operations/extensions/__init__.py
@@ -49,6 +49,23 @@ def _invalidate_command_index():
             pass
 
 
+def _ensure_egg_info(path):
+    # editable_mode=compat + --no-build-isolation results in a PEP 660 editable install:
+    # the .dist-info goes to site-packages and no .egg-info is left in the source tree.
+    # azdev finds dev extensions by globbing *.egg-info under the repo, so without it the
+    # extension is invisible even though pip succeeded. Regenerate it with the env's setuptools.
+    if find_files(path, '*.egg-info'):
+        return
+    result = py_cmd(
+        'setup.py egg_info',
+        "Generating metadata for '{}'...".format(path),
+        is_module=False,
+        cwd=path,
+    )
+    if result.error:
+        raise result.error  # pylint: disable=raising-bad-type
+
+
 def add_extension(extensions):
 
     ext_paths = get_ext_repo_paths()
@@ -78,6 +95,7 @@ def add_extension(extensions):
         )
         if result.error:
             raise result.error  # pylint: disable=raising-bad-type
+        _ensure_egg_info(path)
 
     _invalidate_command_index()
 

--- a/azdev/operations/setup.py
+++ b/azdev/operations/setup.py
@@ -13,7 +13,7 @@ from knack.log import get_logger
 from knack.util import CLIError
 
 from azdev.operations.extensions import (
-    list_extensions, add_extension_repo, remove_extension)
+    list_extensions, add_extension_repo, remove_extension, _ensure_egg_info)
 from azdev.params import Flag
 from azdev.utilities import (
     display, heading, subheading, pip_cmd, CommandError, find_file,
@@ -55,6 +55,7 @@ def _install_extensions(ext_paths):
                          "Adding extension '{}'...".format(path))
         if result.error:
             raise result.error  # pylint: disable=raising-bad-type
+        _ensure_egg_info(path)
 
 
 def _install_cli(cli_path, deps=None):


### PR DESCRIPTION
…tion

pip install -e now does a PEP 660 editable install and no longer leaves an *.egg-info in the extension source tree. azdev discovers dev extensions by globbing *.egg-info, so `azdev extension add` succeeded but the extension stayed invisible to `azdev test` and `azdev extension remove`. Regenerate the egg-info after the editable install in add_extension, _install_extensions and _create_package.

**Related command**
<!--- Please provide the related command with azdev {command} if you can. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] `pylint azdev --rcfile=.pylintrc -r n`

- [ ] `flake8 --statistics --append-config=.flake8 azdev`